### PR TITLE
feat: support stack prefixes as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Allowed values: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.
 - **Mandatory**: No
 - **Default value**: `"INFO"`
 
+### StackPrefix
+
+- **Environment variable**: N/A (only applies to CloudFormation deployments through SAR)
+- **Description**: A prefix to be used for exported outputs. Useful if you need to deploy this stack multiple times in the same account.
+- **Mandatory**: No
+- **Default value**: `""`
+
+For instance, If you set this parameter to `"Test"`, the ARN of the deployed authorizer when using SAR will be exported as `"TestOidcAuthorizerArn"`.
+
 
 ## 🛑 Validation Flow
 

--- a/template.yml
+++ b/template.yml
@@ -84,6 +84,10 @@ Parameters:
     MaxValue: "10240"
     Description: The amount of memory (in MB) to give to the authorizer Lambda.
     Default: "128"
+  StackPrefix:
+    Type: String
+    Description: A prefix to be used for exported outputs. Useful if you need to deploy this stack multiple times in the same account.
+    Default: ""
 
 Resources:
   OidcAuthorizer:
@@ -114,4 +118,4 @@ Outputs:
     Description: The ARN of the OIDC Authorizer Lambda function
     Value: !GetAtt OidcAuthorizer.Arn
     Export:
-      Name: OidcAuthorizerArn
+      Name: !Sub "${StackPrefix}OidcAuthorizerArn"


### PR DESCRIPTION
Allows to specify stack parameters, useful when you need to deploy the same stack from SAR multiple times in the same account.