### PR TITLE
feat: deny delete creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .aws-sam/
 .env
 tests/test-event.json
+tarpaulin-report.html

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: 80% 
         threshold: 5%
+    patch:
+      default:
+        target: 80% 
+        threshold: 5%

--- a/src/models.rs
+++ b/src/models.rs
@@ -38,6 +38,7 @@ pub struct TokenAuthorizerResponse {
 }
 
 impl TokenAuthorizerResponse {
+    #[inline]
     pub fn allow(principal_id: &str, token_claims: &Value) -> Self {
         let mut context = HashMap::new();
         context.insert(
@@ -62,6 +63,7 @@ impl TokenAuthorizerResponse {
         }
     }
 
+    #[inline]
     pub fn deny(resource: &str) -> Self {
         Self {
             context: HashMap::new(),


### PR DESCRIPTION
Hi Luciano,
since `deny` is one of the last thing to be used before returning a response, with this PR I would like to delay its creation as long as we can in order to avoid always creating it for valid token.