### PR TITLE
Add User-Agent header to reqwest client for JWKS request

### DIFF
--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -29,7 +29,7 @@ impl KeysStorage {
         Self {
             jwks_uri,
             min_refresh_rate,
-            client: Client::builder().user_agent("oidc-authorizer/0.1.0").build().unwrap(),
+            client: Client::builder().user_agent(format!("oidc-authorizer/{}", env!("CARGO_PKG_VERSION"))).build().unwrap(),
             storage: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
         }
     }

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -29,7 +29,10 @@ impl KeysStorage {
         Self {
             jwks_uri,
             min_refresh_rate,
-            client: Client::builder().user_agent(format!("oidc-authorizer/{}", env!("CARGO_PKG_VERSION"))).build().unwrap(),
+            client: Client::builder()
+                .user_agent(format!("oidc-authorizer/{}", env!("CARGO_PKG_VERSION")))
+                .build()
+                .unwrap(),
             storage: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
         }
     }

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -29,7 +29,7 @@ impl KeysStorage {
         Self {
             jwks_uri,
             min_refresh_rate,
-            client: Client::new(),
+            client: Client::builder().user_agent("oidc-authorizer/0.1.0").build().unwrap(),
             storage: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
         }
     }


### PR DESCRIPTION
Please consider adding a User-Agent header to the reqwest client. Otherwise, the request is blocked by the NoUserAgent_HEADER rule of the AWSManagedRulesCommonRuleSet in AWS WAF.