### PR TITLE
update dependencies; use jsonwebtoken 9's support for validating "aud" and "iss" claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,12 +294,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1107,13 +1101,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
+ "js-sys",
  "pem",
- "ring 0.16.20",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -1435,11 +1430,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -1600,7 +1596,7 @@ dependencies = [
  "getrandom 0.3.3",
  "lru-slab",
  "rand",
- "ring 0.17.14",
+ "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -1777,21 +1773,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -1800,7 +1781,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -1836,7 +1817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1859,9 +1840,9 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2027,12 +2008,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2446,12 +2421,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 [dependencies]
 chrono = "0.4.31"
 futures-util = "0.3.28"
-jsonwebtoken = "8.3.0"
+jsonwebtoken = "9.3.1"
 lambda_runtime = "0.14.2"
 reqwest = { version = "0.12.3", default_features = false, features = [
   "json",

--- a/src/accepted_claims.rs
+++ b/src/accepted_claims.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use std::{collections::HashSet, fmt::Display};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
@@ -35,6 +34,10 @@ impl AcceptedClaims {
         Self(accepted_values, claim_name)
     }
 
+    pub fn accepted_values(&self) -> Vec<String> {
+        self.0.iter().cloned().collect()
+    }
+
     pub fn from_comma_separated_values(comma_separated_values: &str, claim_name: String) -> Self {
         let accepted_values = comma_separated_values
             .split(',')
@@ -44,62 +47,10 @@ impl AcceptedClaims {
 
         Self::new(accepted_values.into_iter().collect(), claim_name)
     }
-
-    pub fn is_accepted(&self, claim_value: &StringOrArray) -> bool {
-        self.0.is_empty()
-            || match claim_value {
-                StringOrArray::String(claim_value) => self.0.contains(*claim_value),
-                StringOrArray::Array(claim_values) => claim_values
-                    .iter()
-                    .any(|claim_value| self.0.contains(claim_value)),
-            }
-    }
-
-    pub fn assert(&self, claims: &Value) -> Result<(), String> {
-        if self.0.is_empty() {
-            // if empty do not validate
-            return Ok(());
-        }
-
-        let claim_value = match claims.get(&self.1) {
-            Some(claim_value) => match claim_value {
-                Value::String(claim_value) => StringOrArray::String(claim_value),
-                Value::Array(claim_values) => {
-                    let claim_values = claim_values
-                        .iter()
-                        .map(|claim_value| match claim_value {
-                            Value::String(claim_value) => Ok(claim_value.to_string()),
-                            _ => Err(format!(
-                                "Claim '{}' is not a string or an array of strings",
-                                self.1
-                            )),
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
-                    StringOrArray::Array(claim_values)
-                }
-                _ => {
-                    return Err(format!(
-                        "Claim '{}' is not a string or an array of strings",
-                        self.1
-                    ))
-                }
-            },
-            None => return Err(format!("Missing claim '{}'", self.1)),
-        };
-
-        match self.is_accepted(&claim_value) {
-            true => Ok(()),
-            false => Err(format!(
-                "Unsupported value for claim '{}' (found='{}', supported={:?})",
-                self.1, claim_value, self.0
-            )),
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
 
     use super::*;
 
@@ -121,112 +72,6 @@ mod tests {
                 .collect(),
                 "iss".to_string()
             )
-        );
-    }
-
-    #[test]
-    fn it_should_accept_expected_claims_and_reject_others() {
-        // example.com and example.org are accepted
-        // example.net is not accepted
-
-        let accepted_claims = AcceptedClaims::from_comma_separated_values(
-            "https://example.com, https://example.org",
-            "iss".to_string(),
-        );
-
-        assert!(accepted_claims.is_accepted(&"https://example.com".into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": "https://example.com"}))
-            .is_ok());
-        assert!(accepted_claims.is_accepted(&"https://example.org".into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": "https://example.org"}))
-            .is_ok());
-
-        // if the claim is an array, it should accept if at least one of the values is accepted
-        assert!(accepted_claims
-            .assert(&json!({"iss": ["https://example.net", "https://example.com"]}))
-            .is_ok());
-
-        // do not accept example.net (not listed)
-        assert!(!accepted_claims.is_accepted(&"https://example.net".into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": "https://example.net"}))
-            .is_err());
-
-        // do not accept example.net (not listed) even when an array of claims was provided in the token
-        assert!(!accepted_claims
-            .is_accepted(&["https://example.net", "https://example.tld"][..].into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": ["https://example.net", "https://example.tld"]}))
-            .is_err(),);
-    }
-
-    #[test]
-    fn it_should_accept_everything_when_using_an_empty_list() {
-        let accepted_claims = AcceptedClaims::from_comma_separated_values("", "iss".to_string());
-
-        assert!(accepted_claims.is_accepted(&"https://example.com".into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": "https://example.com"}))
-            .is_ok());
-        assert!(accepted_claims.is_accepted(&"https://example.org".into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": "https://example.org"}))
-            .is_ok());
-        assert!(accepted_claims.is_accepted(&"https://example.net".into()));
-        assert!(accepted_claims
-            .assert(&json!({"iss": "https://example.net"}))
-            .is_ok());
-        // it should accept an array of strings
-        assert!(accepted_claims
-            .assert(&json!({"iss": ["https://example.net", "https://example.com"]}))
-            .is_ok());
-        // it should also accept tokens with the missing claim
-        assert!(accepted_claims
-            .assert(&json!({"some_other_claim": "some_value"}))
-            .is_ok());
-    }
-
-    #[test]
-    fn it_should_reject_if_the_claim_is_missing() {
-        let accepted_claims = AcceptedClaims::from_comma_separated_values(
-            "https://example.com, https://example.org",
-            "iss".to_string(),
-        );
-
-        let result = accepted_claims.assert(&json!({
-            "some_other_claim": "some_value"
-        }));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Missing claim 'iss'".to_string());
-    }
-
-    #[test]
-    fn it_should_reject_if_the_claim_is_not_a_string_or_an_array_of_strings() {
-        let accepted_claims = AcceptedClaims::from_comma_separated_values(
-            "https://example.com, https://example.org",
-            "iss".to_string(),
-        );
-
-        // not a string
-        let result = accepted_claims.assert(&json!({
-            "iss": 22
-        }));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            "Claim 'iss' is not a string or an array of strings".to_string()
-        );
-
-        // not an array of string
-        let result = accepted_claims.assert(&json!({
-            "iss": ["https://example.com", 22, "https://example.org"]
-        }));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            "Claim 'iss' is not a string or an array of strings".to_string()
         );
     }
 }


### PR DESCRIPTION
1. update the versions of some dependencies in order to address issues called out by auditing tools
1. use jsonwebtoken 9's own support for validating "aud" and "iss" claims

Switching to jsonwebtoken's own support for validating the claims was motivated in part by upgrading to jsonwebtoken 9, which introduced a behavioral change related to how it validates the "aud" claim. 