### PR TITLE
L2 cache

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*.rs]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+end_of_line = lf
+max_line_length = 120
+tab_width = 4

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: rustsec/audit-check@v1.4.1
+      - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2023-0071: rsa timing sidechannel — only affects decryption, not signature verification
+          # RUSTSEC-2024-0436: paste unmaintained — transitive dep of cel-interpreter, low risk
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ This is an AWS Lambda authorizer for API Gateway that validates OIDC-issued JWT 
 ### Key Design Decisions
 
 - Static lifetime references (`Box::leak`) for handler dependencies to satisfy Lambda runtime requirements
+- Two-level JWKS caching - L1 (in-memory) and L2 (file-based pre-cache) for optimal cold start performance
 - Optimistic JWKS caching - keys refresh only on cache miss, rate-limited by `MIN_REFRESH_RATE`
 - Allow policy uses wildcard resource (`*`) to avoid cache conflicts across endpoints
 
@@ -77,6 +78,7 @@ This is an AWS Lambda authorizer for API Gateway that validates OIDC-issued JWT 
 - `ACCEPTED_AUDIENCES` - Comma-separated list of valid `aud` values
 - `ACCEPTED_ALGORITHMS` - Comma-separated list of valid signing algorithms (ES256, RS256, etc.)
 - `MIN_REFRESH_RATE` - Seconds between JWKS refreshes (default: 900)
+- `JWKS_PRE_CACHED_FILE_PATH` - Optional path to pre-cached JWKS file for faster cold starts
 - `PRINCIPAL_ID_CLAIMS` - Claims to use for principal ID (default: "preferred_username, sub")
 - `DEFAULT_PRINCIPAL_ID` - Fallback principal ID (default: "unknown")
 - `TOKEN_VALIDATION_CEL` - CEL expression for custom token validation (optional, see below)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@ cargo clippy -- -D warnings
 
 # Generate code coverage (requires cargo-llvm-cov)
 cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+# Run security audit (requires cargo-audit)
+# RUSTSEC-2023-0071: rsa timing sidechannel — only affects decryption, not signature verification (safe to ignore)
+# RUSTSEC-2024-0436: paste unmaintained — transitive dep of cel-interpreter, low risk
+cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0436
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ This is an AWS Lambda authorizer for API Gateway that validates OIDC-issued JWT 
 ### Key Design Decisions
 
 - Static lifetime references (`Box::leak`) for handler dependencies to satisfy Lambda runtime requirements
-- Two-level JWKS caching - L1 (in-memory) and L2 (file-based pre-cache) for optimal cold start performance
+- Optional JWKS cache pre-warming from a file on disk (e.g., Lambda layer) for faster cold starts
 - Optimistic JWKS caching - keys refresh only on cache miss, rate-limited by `MIN_REFRESH_RATE`
 - Allow policy uses wildcard resource (`*`) to avoid cache conflicts across endpoints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ This is an AWS Lambda authorizer for API Gateway that validates OIDC-issued JWT 
    - Evaluates CEL expression against token header and claims (if configured)
    - Returns Allow/Deny policy document
 
-3. **keys_storage.rs** - Async JWKS key cache with rate-limited refresh. Uses `RwLock` for concurrent access. Fetches keys from OIDC provider's JWKS endpoint and caches them.
+3. **keys_storage.rs** - Async JWKS key cache with rate-limited refresh. Uses `RwLock` for concurrent access. Optionally pre-warms from a file on disk at startup. Fetches keys from OIDC provider's JWKS endpoint on cache miss and emits a structured `jwks_refresh_needed` log event when pre-warming was active.
 
 4. **keysmap.rs** - Wraps `HashMap<String, DecodingKey>` for storing decoded public keys by `kid`.
 
@@ -78,7 +78,7 @@ This is an AWS Lambda authorizer for API Gateway that validates OIDC-issued JWT 
 - `ACCEPTED_AUDIENCES` - Comma-separated list of valid `aud` values
 - `ACCEPTED_ALGORITHMS` - Comma-separated list of valid signing algorithms (ES256, RS256, etc.)
 - `MIN_REFRESH_RATE` - Seconds between JWKS refreshes (default: 900)
-- `JWKS_PRE_CACHED_FILE_PATH` - Optional path to pre-cached JWKS file for faster cold starts
+- `JWKS_PRE_CACHED_FILE_PATH` - Optional path to pre-cached JWKS file for pre-warming the cache at startup (e.g., `/opt/jwks.json` from a Lambda layer). Emits `event_type=jwks_refresh_needed` log when a cache miss triggers a network refresh.
 - `PRINCIPAL_ID_CLAIMS` - Claims to use for principal ID (default: "preferred_username, sub")
 - `DEFAULT_PRINCIPAL_ID` - Fallback principal ID (default: "unknown")
 - `TOKEN_VALIDATION_CEL` - CEL expression for custom token validation (optional, see below)
@@ -134,6 +134,12 @@ claims.iss == "https://issuer.example.com" && header.kid.startsWith("issuer-")
 - If CEL compilation fails at startup, the Lambda fails to initialize
 - If CEL execution fails at runtime, the request is denied (fail closed)
 
+## CloudFormation Parameters
+
+These are SAM template parameters (not environment variables):
+
+- `LambdaLayers` - Comma-separated list of Lambda layer ARNs to attach (e.g., JWKS pre-cache layer, monitoring extensions)
+
 ## Testing
 
-Tests use `httpmock` to simulate JWKS endpoints. Test fixtures in `tests/fixtures/keys/` contain key pairs for various algorithms (RS256, RS384, RS512, ES256, ES384, PS256, PS384, PS512, EdDSA).
+Tests use `httpmock` to simulate JWKS endpoints. Test fixtures in `tests/fixtures/keys/` contain key pairs for various algorithms (RS256, RS384, RS512, ES256, ES384, PS256, PS384, PS512, EdDSA). Pre-warming tests use `tempfile` for temporary JWKS files and `tracing-test` to verify structured log events.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1072,9 +1072,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1088,10 +1088,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1252,9 +1254,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1317,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1834,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2562,9 +2564,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2617,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2630,23 +2632,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2654,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2667,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -2710,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3071,18 +3069,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1083,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda-extension"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dacd46cb4a3ad2bff64f27d1711ad7bed77e8aa244fd244b84d4cf280586a023"
+dependencies = [
+ "async-stream",
+ "chrono",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "lambda_runtime_api_client",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "lambda_runtime"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1117,7 @@ dependencies = [
  "http-body-util",
  "http-serde",
  "hyper",
+ "lambda-extension",
  "lambda_runtime_api_client",
  "pin-project",
  "serde",
@@ -1316,6 +1347,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
 ]
@@ -2346,6 +2378,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,9 +942,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1080,6 +1092,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1415,6 +1428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1701,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,9 +160,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -169,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -181,18 +187,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -239,9 +245,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -310,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -358,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -508,15 +514,21 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -529,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -544,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -554,15 +566,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -571,15 +583,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -588,15 +600,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -606,9 +618,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -618,15 +630,14 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -655,9 +666,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -692,6 +716,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -719,6 +752,12 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hkdf"
@@ -795,9 +834,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511f510e9b1888d67f10bab4397f8b019d2a9b249a2c10acbce2d705b1b32e26"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -821,7 +860,7 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -869,14 +908,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -893,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -997,6 +1035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,20 +1068,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -1045,15 +1091,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1084,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "lambda-extension"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacd46cb4a3ad2bff64f27d1711ad7bed77e8aa244fd244b84d4cf280586a023"
+checksum = "a9faf9ce430157a8ae72486f7c106885ed3e996c8ac1a9cd3ff82e5d08b541af"
 dependencies = [
  "async-stream",
  "chrono",
@@ -1105,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0b4409eea054e4c06f0101fed547b2cf208e8eca9dc6d41dead4114577852b"
+checksum = "7c58c2197a86a6b73fdc61f18be54de1b1f7681d2df91e49798eac6ea2d482da"
 dependencies = [
  "async-stream",
  "base64",
@@ -1131,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4873061514cb57ffb6a599b77c46c65d6d783efe9bad8fd56b7cba7f0459ef"
+checksum = "b5e9ffa99f1e87b21d42ac98fe7eac55f4cfb9ed14677a64a7dab4d8f44399a4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1158,10 +1204,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -1213,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1296,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1344,7 +1396,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1354,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "p256"
@@ -1453,18 +1505,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1473,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1529,6 +1581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1560,7 +1622,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1568,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1581,7 +1643,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1603,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1615,6 +1677,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1686,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1698,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1709,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1826,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -1840,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1850,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1867,9 +1935,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -2038,21 +2106,21 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2062,12 +2130,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2106,9 +2174,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2146,12 +2214,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2168,11 +2236,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2188,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2208,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2223,15 +2291,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2249,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2264,9 +2332,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2280,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2387,7 +2455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -2436,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2457,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -2468,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
  "syn",
@@ -2496,15 +2564,21 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2532,9 +2606,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2569,18 +2643,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2591,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2605,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2615,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2628,18 +2711,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2657,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2881,9 +2998,91 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2916,18 +3115,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2996,6 +3195,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,10 +114,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "better_any"
@@ -249,6 +261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +288,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +307,44 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -295,7 +363,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -307,6 +377,65 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -351,6 +480,22 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -476,6 +621,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -503,6 +649,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -552,6 +709,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -877,24 +1052,32 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.5",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
 ]
 
 [[package]]
 name = "lambda_runtime"
-version = "0.14.4"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb1a631df22d6d81314268a94fda06ab15b3fa1fcea660e7c5c162caa8fba6b"
+checksum = "dc0b4409eea054e4c06f0101fed547b2cf208e8eca9dc6d41dead4114577852b"
 dependencies = [
  "async-stream",
  "base64",
@@ -917,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "0.12.4"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3ccfa59944d61c20b98892c84d9e0e8118d722a75beaebe68e69db36b4afe1"
+checksum = "7b4873061514cb57ffb6a599b77c46c65d6d783efe9bad8fd56b7cba7f0459ef"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -939,12 +1122,21 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1056,6 +1248,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,12 +1279,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1105,6 +1325,30 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking"
@@ -1161,6 +1405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1452,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1260,7 +1543,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1303,12 +1586,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1318,7 +1622,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1408,6 +1721,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,10 +1745,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1492,6 +1844,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1581,6 +1953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1986,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1643,6 +2036,22 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "oidc-authorizer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cel-interpreter",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,15 +288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,27 +1120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lambda-extension"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9faf9ce430157a8ae72486f7c106885ed3e996c8ac1a9cd3ff82e5d08b541af"
-dependencies = [
- "async-stream",
- "chrono",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "lambda_runtime_api_client",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "lambda_runtime"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,7 +1133,6 @@ dependencies = [
  "http-body-util",
  "http-serde",
  "hyper",
- "lambda-extension",
  "lambda_runtime_api_client",
  "pin-project",
  "serde",
@@ -1399,7 +1368,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
 ]
@@ -2446,18 +2414,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 chrono = "0.4.31"
 futures-util = "0.3.28"
 jsonwebtoken = { version= "10.3.0", features = ["rust_crypto"] }
-lambda_runtime = {version ="1.0.2", features=["graceful-shutdown"]}
+lambda_runtime = "1.0.2"
 reqwest = { version = "0.12.28", default-features = false, features = [
   "json",
   "rustls-tls",
@@ -34,7 +34,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "fmt",
 ] }
 cel-interpreter = { version = "0.10", features = ["json", "regex", "chrono"] }
-tracing-appender = "0.2.4"
 
 [dev-dependencies]
 httpmock = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 chrono = "0.4.31"
 futures-util = "0.3.28"
 jsonwebtoken = { version= "10.3.0", features = ["rust_crypto"] }
-lambda_runtime = "1.0.2"
+lambda_runtime = {version ="1.0.2", features=["graceful-shutdown"]}
 reqwest = { version = "0.12.28", default-features = false, features = [
   "json",
   "rustls-tls",
@@ -34,6 +34,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "fmt",
 ] }
 cel-interpreter = { version = "0.10", features = ["json", "regex", "chrono"] }
+tracing-appender = "0.2.4"
 
 [dev-dependencies]
 httpmock = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ license = "MIT"
 [dependencies]
 chrono = "0.4.31"
 futures-util = "0.3.28"
-jsonwebtoken = "9.3.1"
-lambda_runtime = "0.14.2"
-reqwest = { version = "0.12.3", default-features = false, features = [
+jsonwebtoken = { version= "10.3.0", features = ["rust_crypto"] }
+lambda_runtime = "1.0.2"
+reqwest = { version = "0.12.28", default-features = false, features = [
   "json",
   "rustls-tls",
   "http2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,5 @@ cel-interpreter = { version = "0.10", features = ["json", "regex", "chrono"] }
 
 [dev-dependencies]
 httpmock = "0.8.2"
+tempfile = "3.26.0"
 tracing-test = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oidc-authorizer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Here's a list of the configuration options that are supported:
 > [!TIP]
 > When the pre-warmed cache is active and a key is not found in it (e.g., because the OIDC provider has rotated keys), the authorizer fetches fresh keys from the JWKS endpoint and emits a structured log line with `event_type=jwks_refresh_needed`. You can use a [CloudWatch Logs subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html) to match this event and trigger an automated update of the pre-cached JWKS Lambda layer.
 
-The easiest way to create a layer is with SAM or CDK directly in your deployment stack. See the [deployment docs](./docs/deploy.md) and the [examples](./examples/) for ready-to-use snippets. For a manual approach using the AWS CLI, see [examples/jwks-lambda-layer/layer.sh](./examples/jwks-lambda-layer/layer.sh).
+For a complete guide on creating and managing the JWKS layer (SAM, CDK, and AWS CLI approaches, plus automated rotation), see [examples/jwks-lambda-layer/README.md](./examples/jwks-lambda-layer/README.md).
 
 ### LambdaLayers
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Here's a list of the configuration options that are supported:
 - **Description**: Optional path to a pre-cached JWKS file on disk. If specified, the authorizer will attempt to load keys from this file before fetching from the JWKS URI endpoint. This can improve cold start performance by avoiding the initial network call. The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format. If the file is invalid or missing, the authorizer will gracefully fall back to fetching from the JWKS URI endpoint. The file path should be accessible from the Lambda execution environment (e.g., `/opt/jwks.json` for Lambda layers, or relative to the Lambda package root).
 - **Mandatory**: No
 - **Default value**: Not set (disabled)
+- **Example Shell script to publish and configure a layer**: [examples/jwks-lambda-layer/layer.sh](./examples/jwks-lambda-layer/layer.sh)
 
 ### PrincipalIdClaims
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Here's a list of the configuration options that are supported:
 - **Mandatory**: No
 - **Default value**: `"900"` (15 minutes)
 
+### JwksPreCachedFilePath
+
+- **Environment variable**: `JWKS_PRE_CACHED_FILE_PATH`
+- **Description**: Optional path to a pre-cached JWKS file on disk. If specified, the authorizer will attempt to load keys from this file before fetching from the JWKS URI endpoint. This can improve cold start performance by avoiding the initial network call. The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format. If the file is invalid or missing, the authorizer will gracefully fall back to fetching from the JWKS URI endpoint. The file path should be accessible from the Lambda execution environment (e.g., `/opt/jwks.json` for Lambda layers, or relative to the Lambda package root).
+- **Mandatory**: No
+- **Default value**: Not set (disabled)
+
 ### PrincipalIdClaims
 
 - **Environment variable**: `PRINCIPAL_ID_CLAIMS`

--- a/README.md
+++ b/README.md
@@ -69,10 +69,22 @@ Here's a list of the configuration options that are supported:
 ### JwksPreCachedFilePath
 
 - **Environment variable**: `JWKS_PRE_CACHED_FILE_PATH`
-- **Description**: Optional path to a pre-cached JWKS file on disk. If specified, the authorizer will attempt to load keys from this file before fetching from the JWKS URI endpoint. This can improve cold start performance by avoiding the initial network call. The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format. If the file is invalid or missing, the authorizer will gracefully fall back to fetching from the JWKS URI endpoint. The file path should be accessible from the Lambda execution environment (e.g., `/opt/jwks.json` for Lambda layers, or relative to the Lambda package root).
+- **Description**: Optional path to a pre-cached JWKS file on disk. When set, the authorizer pre-warms its in-memory key cache from this file at startup, avoiding the initial network call to the JWKS endpoint. This can significantly improve cold start performance. The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format. If the file is missing or invalid, the authorizer logs a warning and starts with an empty cache (gracefully falling back to fetching from the JWKS URI on the first request). The file path should be accessible from the Lambda execution environment (e.g., `/opt/jwks.json` for Lambda layers).
 - **Mandatory**: No
 - **Default value**: Not set (disabled)
-- **Example Shell script to publish and configure a layer**: [examples/jwks-lambda-layer/layer.sh](./examples/jwks-lambda-layer/layer.sh)
+- **Used together with**: `LambdaLayers` (when deploying via CloudFormation/SAR)
+
+> [!TIP]
+> When the pre-warmed cache is active and a key is not found in it (e.g., because the OIDC provider has rotated keys), the authorizer fetches fresh keys from the JWKS endpoint and emits a structured log line with `event_type=jwks_refresh_needed`. You can use a [CloudWatch Logs subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html) to match this event and trigger an automated update of the pre-cached JWKS Lambda layer.
+
+The easiest way to create a layer is with SAM or CDK directly in your deployment stack. See the [deployment docs](./docs/deploy.md) and the [examples](./examples/) for ready-to-use snippets. For a manual approach using the AWS CLI, see [examples/jwks-lambda-layer/layer.sh](./examples/jwks-lambda-layer/layer.sh).
+
+### LambdaLayers
+
+- **CloudFormation parameter** (not an environment variable)
+- **Description**: A comma-separated list of Lambda layer ARNs to attach to the authorizer function. Use this to add a pre-cached JWKS layer (for faster cold starts, together with `JwksPreCachedFilePath`), monitoring extensions, or any other layers you need. This parameter is only relevant when deploying via CloudFormation or SAR.
+- **Mandatory**: No
+- **Default value**: `""` (no layers attached)
 
 ### PrincipalIdClaims
 
@@ -205,7 +217,7 @@ The following section describes the steps that are followed to validate a token:
 
   1. The token is parsed from the `Authorization` header of the request. It is expected to be in the form `Bearer <token>`, where `<token>` needs to be a valid JWT token.
   2. The token is decoded and the header is parsed to extract the `kid` (key id) and the `alg` (algorithm) claims. If the `kid` is not found, the token is rejected. If the `alg` is not supported, the token is rejected.
-  3. The `kid` is used to look up the public key in the JWKS (JSON Web Key Set) provided by the OIDC provider. If the key is not found, the key is refreshed and the lookup is retried. If the key is still not found, the token is rejected. The JWKS cache is optimistic, it does not automatically refresh keys unless a lookup fails. It also does not auto-refresh keys too often (to avoid unnecessary calls to the JWKS endpoint). You can configure the minimum refresh rate (in seconds) using the `MIN_REFRESH_RATE` environment variable.
+  3. The `kid` is used to look up the public key in the in-memory JWKS (JSON Web Key Set) cache. If `JWKS_PRE_CACHED_FILE_PATH` is configured, the cache is pre-warmed from the file at startup so keys are immediately available without a network call. If the key is not found in the cache, the JWKS is refreshed from the OIDC provider and the lookup is retried. If the key is still not found, the token is rejected. The JWKS cache is optimistic: it does not automatically refresh keys unless a lookup fails, and it rate-limits refresh attempts (configurable via `MIN_REFRESH_RATE`).
   4. The token is decoded and validated using the public key. If the validation fails, the token is rejected. This validation also checks the `exp` (expiration time) claim and the `nbf` (not before) claim. If the token is expired or not yet valid, the token is rejected.
   5. The `iss` (issuer) claim is checked against the list of accepted issuers. If the issuer is not found in the list, the token is rejected. If the accept list is empty, any issuer is accepted. If the token contains multiple issuers (array of strings), this check will make sure that at least one of the issuers in the token matches the provided list of accepted issuers.
   6. The `aud` (audience) claim is checked against the list of accepted audiences. If the audience is not found in the list, the token is rejected. If the list is empty, any audience is accepted. If the token contains multiple audiences (array of strings), this check will make sure that at least one of the audiences in the token matches the provided list of accepted audiences.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -22,6 +22,18 @@ Transform: AWS::Serverless-2016-10-31
 Description: AWS SAM template with a simple API definition
 
 Resources:
+  # Optional: Pre-cached JWKS layer for faster cold starts.
+  # Download your JWKS file: mkdir -p jwks-layer && curl -o jwks-layer/jwks.json "YOUR_JWKS_URI"
+  # Then uncomment this resource and the LambdaLayers/JwksPreCachedFilePath lines below.
+  #
+  # JwksPreCacheLayer:
+  #   Type: AWS::Serverless::LayerVersion
+  #   Properties:
+  #     LayerName: !Sub "${AWS::StackName}-jwks-pre-cache"
+  #     ContentUri: jwks-layer/
+  #     CompatibleRuntimes:
+  #       - provided.al2023
+
   # The oidc-authorizer imported from SAR
   oidcauthorizer:
     Type: AWS::Serverless::Application
@@ -37,7 +49,9 @@ Resources:
         DefaultPrincipalId: "unknown"
         JwksUri: "THE ENDPOINT OF YOUR OIDC PROVIDER JWKS"
         MinRefreshRate: "900"
-        JwksPreCachedFilePath: ""
+        # Uncomment to enable pre-warmed JWKS cache (requires JwksPreCacheLayer above)
+        # LambdaLayers: !Ref JwksPreCacheLayer
+        # JwksPreCachedFilePath: "/opt/jwks.json"
         PrincipalIdClaims: "preferred_username, sub"
         TokenValidationCel: ""
         # The amount of memory (in MB) to give to the authorizer Lambda.
@@ -71,6 +85,15 @@ The following snippet shows how to use the SAR application with CDK (using
 Typescript):
 
 ```typescript
+// Optional: Pre-cached JWKS layer for faster cold starts.
+// Download your JWKS file: mkdir -p jwks-layer && curl -o jwks-layer/jwks.json "YOUR_JWKS_URI"
+// Then uncomment the layer and the LambdaLayers/JwksPreCachedFilePath parameters below.
+//
+// const jwksPreCacheLayer = new aws_lambda.LayerVersion(this, 'JwksPreCacheLayer', {
+//   code: aws_lambda.Code.fromAsset('./jwks-layer'),
+//   compatibleRuntimes: [aws_lambda.Runtime.PROVIDED_AL2023],
+// });
+
 // import the authorizer lambda for the Serverless Application Repository
 const authorizerApp = new cdk.aws_sam.CfnApplication(this, "AuthorizerApp", {
   location: {
@@ -87,7 +110,9 @@ const authorizerApp = new cdk.aws_sam.CfnApplication(this, "AuthorizerApp", {
     JwksUri:
       "https://login.microsoftonline.com/3e4abf5a-fdc9-485c-9853-af03c4a32976/discovery/v2.0/keys",
     MinRefreshRate: "900",
-    JwksPreCachedFilePath: "",
+    // Uncomment to enable pre-warmed JWKS cache (requires jwksPreCacheLayer above)
+    // LambdaLayers: jwksPreCacheLayer.layerVersionArn,
+    // JwksPreCachedFilePath: "/opt/jwks.json",
     PrincipalIdClaims: "preferred_username, sub",
     TokenValidationCel: "",
     // The amount of memory (in MB) to give to the authorizer Lambda.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -37,6 +37,7 @@ Resources:
         DefaultPrincipalId: "unknown"
         JwksUri: "THE ENDPOINT OF YOUR OIDC PROVIDER JWKS"
         MinRefreshRate: "900"
+        JwksPreCachedFilePath: ""
         PrincipalIdClaims: "preferred_username, sub"
         TokenValidationCel: ""
         # The amount of memory (in MB) to give to the authorizer Lambda.
@@ -86,6 +87,7 @@ const authorizerApp = new cdk.aws_sam.CfnApplication(this, "AuthorizerApp", {
     JwksUri:
       "https://login.microsoftonline.com/3e4abf5a-fdc9-485c-9853-af03c4a32976/discovery/v2.0/keys",
     MinRefreshRate: "900",
+    JwksPreCachedFilePath: "",
     PrincipalIdClaims: "preferred_username, sub",
     TokenValidationCel: "",
     // The amount of memory (in MB) to give to the authorizer Lambda.

--- a/examples/cdk-from-sar/lib/cdk-stack.ts
+++ b/examples/cdk-from-sar/lib/cdk-stack.ts
@@ -7,6 +7,19 @@ export class CdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    // Optional: Pre-cached JWKS layer for faster cold starts.
+    // To use this, download your JWKS file first:
+    //   mkdir -p jwks-layer && curl -o jwks-layer/jwks.json "YOUR_JWKS_URI"
+    // Then uncomment the layer and the LambdaLayers/JwksPreCachedFilePath parameters below.
+    //
+    // const jwksPreCacheLayer = new aws_lambda.LayerVersion(this, 'JwksPreCacheLayer', {
+    //   layerVersionName: 'jwks-pre-cache',
+    //   description: 'Pre-cached JWKS keys for faster cold starts',
+    //   code: aws_lambda.Code.fromAsset('./jwks-layer'),
+    //   compatibleRuntimes: [aws_lambda.Runtime.PROVIDED_AL2023],
+    //   removalPolicy: cdk.RemovalPolicy.DESTROY,
+    // });
+
     // import the authorizer lambda for the Serverless Application Repository
     const authorizerApp = new cdk.aws_sam.CfnApplication(this, 'AuthorizerApp', {
       location: {
@@ -24,6 +37,9 @@ export class CdkStack extends cdk.Stack {
         PrincipalIdClaims: "preferred_username, sub",
         // A CEL expression for custom token validation (optional)
         TokenValidationCel: "",
+        // Uncomment to enable pre-warmed JWKS cache (requires jwksPreCacheLayer above)
+        // LambdaLayers: jwksPreCacheLayer.layerVersionArn,
+        // JwksPreCachedFilePath: "/opt/jwks.json",
         // The amount of memory (in MB) to give to the authorizer Lambda.
         LambdaMemorySize: "128",
         // The timeout to give to the authorizer Lambda.

--- a/examples/jwks-lambda-layer/README.md
+++ b/examples/jwks-lambda-layer/README.md
@@ -1,0 +1,60 @@
+# Pre-warming the JWKS cache with a Lambda Layer
+
+The oidc-authorizer supports pre-warming its in-memory key cache from a JWKS file on disk at startup. This avoids the initial network call to the OIDC provider's JWKS endpoint, significantly reducing cold start latency.
+
+The recommended way to make a JWKS file available to the Lambda is through a [Lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html). When a layer is attached, its contents are extracted to `/opt/` in the Lambda execution environment.
+
+## When to use this script
+
+**Use `layer.sh`** when you manage layers outside your IaC stack, for example:
+
+- CI/CD pipelines that periodically refresh the JWKS layer
+- Automated rotation triggered by log events (see [Automated layer rotation](#automated-layer-rotation) below)
+- One-off manual updates
+
+**Use SAM or CDK instead** if the layer is part of your infrastructure-as-code stack. Both tools can create layers from a local file in a single deployment:
+
+- **SAM**: use `AWS::Serverless::LayerVersion` with `ContentUri` pointing to a local directory — see [`examples/sam/template.yml`](../sam/template.yml) and [`examples/sam-from-sar/template.yml`](../sam-from-sar/template.yml)
+- **CDK**: use `aws_lambda.LayerVersion` with `Code.fromAsset()` — see [`examples/cdk-from-sar/lib/cdk-stack.ts`](../cdk-from-sar/lib/cdk-stack.ts)
+
+## How it works
+
+The [`layer.sh`](./layer.sh) script:
+
+1. Downloads the JWKS JSON from your OIDC provider's endpoint
+2. Packages it into a zip file (the file will be available at `/opt/jwks.json` in Lambda)
+3. Publishes the zip as a new Lambda layer version
+4. Attaches the layer to your authorizer Lambda function
+
+After running the script, set the `JWKS_PRE_CACHED_FILE_PATH` environment variable on your authorizer Lambda to `/opt/jwks.json`.
+
+### Prerequisites
+
+- [AWS CLI](https://aws.amazon.com/cli/) (configured with appropriate permissions)
+- `curl`, `zip`, `jq`
+
+### Usage
+
+Edit the variables at the top of `layer.sh` and run:
+
+```bash
+bash layer.sh
+```
+
+## Automated layer rotation
+
+The pre-cached JWKS file is a snapshot — if the OIDC provider rotates its keys (i.e. when a token signed by a new key is encountered), the file becomes stale. The authorizer handles this gracefully by falling back to a network fetch, but cold starts will temporarily lose the pre-warming benefit until the layer is updated.
+
+To automate layer updates, the authorizer emits a structured log line when it detects a cache miss on a pre-warmed cache:
+
+```
+event_type=jwks_refresh_needed jwks_uri=https://... key_id=...
+  Pre-warmed JWKS cache miss. Keys refreshed from JWKS endpoint. Consider updating the pre-cached JWKS file.
+```
+
+You can use this log event to trigger an automated layer update:
+
+1. Create a [CloudWatch Logs subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html) on the authorizer's log group, matching the pattern `"jwks_refresh_needed"`
+2. Route the event to a target that regenerates the layer (e.g., a Lambda function that runs this script, an SNS topic, or a Step Function)
+
+This makes layer updates event-driven: the layer is regenerated only when the OIDC provider actually rotates keys, rather than on a fixed schedule.

--- a/examples/jwks-lambda-layer/layer.sh
+++ b/examples/jwks-lambda-layer/layer.sh
@@ -1,66 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads JWKS from your OIDC provider, packages it as a Lambda layer,
+# and attaches it to your authorizer function.
+# See the README.md in this directory for full context and alternative approaches.
+
 JWKS_URI="<YOUR_JWKS_URI_HERE>"
 AUTH_LAMBDA_FUNCTION_NAME="<YOUR_LAMBDA_FUNCTION_NAME_HERE>"
 LAMBDA_LAYER_NAME="<YOUR_LAMBDA_LAYER_NAME_HERE>"
-JWKS_CACHE_DIR="./.jwks-cache"
 
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
 
-echo "--------------------------------"
-echo "Current directory: $(pwd)"
-echo "--------------------------------"
-echo "Downloading JWKS from $JWKS_URI"
-mkdir -p $JWKS_CACHE_DIR
-curl -o $JWKS_CACHE_DIR/jwks.json $JWKS_URI
-echo ""
-echo "--------------------------------"
-echo "Zipping JWKS"
-# create a new zip file
-rm -f jwks-layer.zip
-zip -FSr jwks-layer.zip $JWKS_CACHE_DIR/
-echo ""
-echo "--------------------------------"
-unzip -l jwks-layer.zip
-echo ""
-echo "--------------------------------"
-echo "Publishing layer to AWS..."
-echo ""
+echo "Downloading JWKS from ${JWKS_URI}..."
+curl -sf -o "${WORK_DIR}/jwks.json" "${JWKS_URI}"
+
+echo "Packaging layer..."
+(cd "${WORK_DIR}" && zip -j jwks-layer.zip jwks.json)
+
+echo "Publishing layer..."
 layer_version=$(aws lambda publish-layer-version \
   --output json \
   --no-cli-pager \
   --no-cli-auto-prompt \
-  --layer-name $LAMBDA_LAYER_NAME \
-  --zip-file fileb://jwks-layer.zip)
+  --layer-name "${LAMBDA_LAYER_NAME}" \
+  --zip-file "fileb://${WORK_DIR}/jwks-layer.zip")
 
-if [ $? -ne 0 ]; then
-  echo "Failed to publish layer."
-  exit 1
-fi
+layer_version_arn=$(echo "${layer_version}" | jq -r '.LayerVersionArn')
+echo "Published layer: ${layer_version_arn}"
 
-echo $layer_version | jq
-
-layer_version_arn=$(echo $layer_version | jq -r '.LayerVersionArn')
-
-echo ""
-echo "--------------------------------"
-echo "Configuring version arn on authorizer lambda."
-echo "Layer ARN: $layer_version_arn"
-echo "Target Function: $AUTH_LAMBDA_FUNCTION_NAME"
-
+echo "Attaching layer to ${AUTH_LAMBDA_FUNCTION_NAME}..."
 aws lambda update-function-configuration \
   --output json \
   --no-cli-pager \
   --no-cli-auto-prompt \
-  --function-name $AUTH_LAMBDA_FUNCTION_NAME \
-  --layers $layer_version_arn \
-  | jq
+  --function-name "${AUTH_LAMBDA_FUNCTION_NAME}" \
+  --layers "${layer_version_arn}" \
+  | jq '{FunctionName, Layers}'
 
 echo ""
-
-
-echo "--------------------------------"
-echo "FYI:"
-echo "--------------------------------"
-echo "When this layer is configured on the lambda function, the zip file will be extracted to /opt/"
-echo "So, the 'JWKS_PRE_CACHED_FILE_PATH' would be '/opt/.jwks-cache/jwks.json'"
-echo "--------------------------------"
-echo "TODO: Conditional publish of layer based on if the jwks contents have changed or not is left to you."
-echo "--------------------------------"
+echo "Done! Set the following environment variable on your authorizer Lambda:"
+echo "  JWKS_PRE_CACHED_FILE_PATH=/opt/jwks.json"

--- a/examples/jwks-lambda-layer/layer.sh
+++ b/examples/jwks-lambda-layer/layer.sh
@@ -1,0 +1,66 @@
+JWKS_URI="<YOUR_JWKS_URI_HERE>"
+AUTH_LAMBDA_FUNCTION_NAME="<YOUR_LAMBDA_FUNCTION_NAME_HERE>"
+LAMBDA_LAYER_NAME="<YOUR_LAMBDA_LAYER_NAME_HERE>"
+JWKS_CACHE_DIR="./.jwks-cache"
+
+
+echo "--------------------------------"
+echo "Current directory: $(pwd)"
+echo "--------------------------------"
+echo "Downloading JWKS from $JWKS_URI"
+mkdir -p $JWKS_CACHE_DIR
+curl -o $JWKS_CACHE_DIR/jwks.json $JWKS_URI
+echo ""
+echo "--------------------------------"
+echo "Zipping JWKS"
+# create a new zip file
+rm -f jwks-layer.zip
+zip -FSr jwks-layer.zip $JWKS_CACHE_DIR/
+echo ""
+echo "--------------------------------"
+unzip -l jwks-layer.zip
+echo ""
+echo "--------------------------------"
+echo "Publishing layer to AWS..."
+echo ""
+layer_version=$(aws lambda publish-layer-version \
+  --output json \
+  --no-cli-pager \
+  --no-cli-auto-prompt \
+  --layer-name $LAMBDA_LAYER_NAME \
+  --zip-file fileb://jwks-layer.zip)
+
+if [ $? -ne 0 ]; then
+  echo "Failed to publish layer."
+  exit 1
+fi
+
+echo $layer_version | jq
+
+layer_version_arn=$(echo $layer_version | jq -r '.LayerVersionArn')
+
+echo ""
+echo "--------------------------------"
+echo "Configuring version arn on authorizer lambda."
+echo "Layer ARN: $layer_version_arn"
+echo "Target Function: $AUTH_LAMBDA_FUNCTION_NAME"
+
+aws lambda update-function-configuration \
+  --output json \
+  --no-cli-pager \
+  --no-cli-auto-prompt \
+  --function-name $AUTH_LAMBDA_FUNCTION_NAME \
+  --layers $layer_version_arn \
+  | jq
+
+echo ""
+
+
+echo "--------------------------------"
+echo "FYI:"
+echo "--------------------------------"
+echo "When this layer is configured on the lambda function, the zip file will be extracted to /opt/"
+echo "So, the 'JWKS_PRE_CACHED_FILE_PATH' would be '/opt/.jwks-cache/jwks.json'"
+echo "--------------------------------"
+echo "TODO: Conditional publish of layer based on if the jwks contents have changed or not is left to you."
+echo "--------------------------------"

--- a/examples/sam-from-sar/template.yml
+++ b/examples/sam-from-sar/template.yml
@@ -18,6 +18,21 @@ Transform: AWS::Serverless-2016-10-31
 Description: AWS SAM template with a simple API definition
 
 Resources:
+  # Optional: Pre-cached JWKS layer for faster cold starts.
+  # To use this, download your JWKS file first:
+  #   mkdir -p jwks-layer && curl -o jwks-layer/jwks.json "YOUR_JWKS_URI"
+  # Then uncomment the layer resource and the LambdaLayers/JwksPreCachedFilePath lines below.
+  #
+  # JwksPreCacheLayer:
+  #   Type: AWS::Serverless::LayerVersion
+  #   Properties:
+  #     LayerName: !Sub "${AWS::StackName}-jwks-pre-cache"
+  #     Description: Pre-cached JWKS keys for faster cold starts
+  #     ContentUri: jwks-layer/
+  #     CompatibleRuntimes:
+  #       - provided.al2023
+  #     RetentionPolicy: Delete
+
   # The oidc-authorizer imported from SAR
   oidcauthorizer:
     Type: AWS::Serverless::Application
@@ -36,6 +51,9 @@ Resources:
         PrincipalIdClaims: "preferred_username, sub"
         # A CEL expression for custom token validation (optional)
         TokenValidationCel: ""
+        # Uncomment to enable pre-warmed JWKS cache (requires JwksPreCacheLayer above)
+        # LambdaLayers: !Ref JwksPreCacheLayer
+        # JwksPreCachedFilePath: "/opt/jwks.json"
         # The amount of memory (in MB) to give to the authorizer Lambda.
         LambdaMemorySize: "128"
         # The timeout to give to the authorizer Lambda.

--- a/examples/sam/template.yml
+++ b/examples/sam/template.yml
@@ -64,6 +64,21 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-OidcLambdaAuthorizer"
       RetentionInDays: 30
 
+  # Optional: Pre-cached JWKS layer for faster cold starts.
+  # To use this, download your JWKS file first:
+  #   mkdir -p jwks-layer && curl -o jwks-layer/jwks.json "YOUR_JWKS_URI"
+  # Then uncomment the layer resource and the Layers/JWKS_PRE_CACHED_FILE_PATH lines below.
+  #
+  # JwksPreCacheLayer:
+  #   Type: AWS::Serverless::LayerVersion
+  #   Properties:
+  #     LayerName: !Sub "${AWS::StackName}-jwks-pre-cache"
+  #     Description: Pre-cached JWKS keys for faster cold starts
+  #     ContentUri: jwks-layer/
+  #     CompatibleRuntimes:
+  #       - provided.al2023
+  #     RetentionPolicy: Delete
+
   # Authorizer Lambda
   OidcLambdaAuthorizer:
     Type: AWS::Serverless::Function
@@ -77,6 +92,8 @@ Resources:
       MemorySize: 128 # 👀 CHANGE IF NEEDED
       Architectures:
         - arm64
+      # Layers:
+      #   - !Ref JwksPreCacheLayer
       LoggingConfig:
         LogGroup: !Ref OidcLambdaAuthorizerLogGroup
       Environment:
@@ -91,6 +108,8 @@ Resources:
           ACCEPTED_ALGORITHMS: ""
           # A CEL expression for custom token validation (optional)
           TOKEN_VALIDATION_CEL: ""
+          # Uncomment to enable pre-warmed JWKS cache (requires JwksPreCacheLayer above)
+          # JWKS_PRE_CACHED_FILE_PATH: "/opt/jwks.json"
 
   # 👀 CHANGE: Define your APIs here
   SampleApiFunction1:

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -164,6 +164,7 @@ mod tests {
         let key_storage = Box::leak(Box::new(KeysStorage::new(
             Url::parse("http://localhost").unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
         let principal_id_claims =
             Box::leak(Box::new(PrincipalIDClaims::from_comma_separated_values(
@@ -231,7 +232,7 @@ mod tests {
             AcceptedClaims::from_comma_separated_values(aud, "aud".to_string());
         let accepted_signing_algorithms: AcceptedAlgorithms = Default::default();
         let cel_validator: CelValidator = Default::default();
-        let keys = KeysStorage::new(Url::parse(&jwks_uri).unwrap(), min_refresh_rate);
+        let keys = KeysStorage::new(Url::parse(&jwks_uri).unwrap(), min_refresh_rate, None);
         let mut handler = Handler::new(
             Box::leak(Box::new(keys)),
             Box::leak(Box::new(principal_id_claims)),
@@ -512,6 +513,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
 
         let response = handler.do_call(event).await;
@@ -560,6 +562,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
 
         let response = handler.do_call(event).await;
@@ -607,6 +610,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
 
         let response = handler.do_call(event).await;
@@ -654,6 +658,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
 
         let response = handler.do_call(event).await;
@@ -702,6 +707,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
         // CEL expression that requires email_verified to be true
         let cel_validator: CelValidator = "claims.email_verified == true".parse().unwrap();
@@ -753,6 +759,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
         // CEL expression that requires email_verified to be true
         let cel_validator: CelValidator = "claims.email_verified == true".parse().unwrap();
@@ -804,6 +811,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
         // CEL expression that requires admin role
         let cel_validator: CelValidator =
@@ -855,6 +863,7 @@ mod tests {
         handler.keys = Box::leak(Box::new(KeysStorage::new(
             Url::parse(&server.url("/")).unwrap(),
             Duration::try_seconds(600).unwrap(),
+            None,
         )));
         // CEL expression that requires admin role
         let cel_validator: CelValidator =

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,7 +11,6 @@ use futures_util::future::{BoxFuture, FutureExt};
 use jsonwebtoken::{decode, decode_header, Validation};
 use lambda_runtime::{Error, LambdaEvent, Service};
 use std::task::{Context, Poll};
-use std::time::Instant;
 
 pub struct Handler {
     pub keys: &'static KeysStorage,
@@ -71,7 +70,6 @@ impl Handler {
             return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
         }
 
-        let start_time = Instant::now();
         let key = match &token_header.kid {
             Some(key_id) => match self.keys.get(key_id).await {
                 Ok(key) => key,
@@ -88,9 +86,7 @@ impl Handler {
                 return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
             }
         };
-        tracing::info!("Key retrieval overall took: {:?}", start_time.elapsed());
 
-        let start_time = Instant::now();
         let mut validation = Validation::new(token_header.alg);
         validation.set_audience(&self.accepted_audiences.accepted_values());
         validation.set_issuer(&self.accepted_issuers.accepted_values());
@@ -101,9 +97,7 @@ impl Handler {
                 return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
             }
         };
-        tracing::info!("Token validation took: {:?}", start_time.elapsed());
 
-        let start_time = Instant::now();
         // CEL validation (if configured)
         if let Err(e) = self
             .cel_validator
@@ -116,13 +110,10 @@ impl Handler {
             );
             return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
         }
-        tracing::info!("CEL validation took: {:?}", start_time.elapsed());
 
-        let start_time = Instant::now();
         let principal_id = self
             .principal_id_claims
             .get_principal_id_from_claims(&token_payload.claims);
-        tracing::info!("Principal ID extraction took: {:?}", start_time.elapsed());
 
         Ok(TokenAuthorizerResponse::allow(
             &principal_id,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -71,6 +71,7 @@ impl Handler {
             return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
         }
 
+        let start_time = Instant::now();
         let key = match &token_header.kid {
             Some(key_id) => match self.keys.get(key_id).await {
                 Ok(key) => key,
@@ -87,6 +88,7 @@ impl Handler {
                 return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
             }
         };
+        tracing::info!("Key retrieval overall took: {:?}", start_time.elapsed());
 
         let start_time = Instant::now();
         let mut validation = Validation::new(token_header.alg);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -878,4 +878,137 @@ mod tests {
         assert_eq!(statement.effect, "Allow");
         assert_eq!(response.principal_id, "some_user");
     }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn it_validates_tokens_across_pre_warmed_cache_and_network_refresh() {
+        use tempfile::NamedTempFile;
+
+        let rs256_jwk = include_str!("../tests/fixtures/keys/rs256/jwk.json");
+        let rs384_jwk = include_str!("../tests/fixtures/keys/rs384/jwk.json");
+        let rs512_jwk = include_str!("../tests/fixtures/keys/rs512/jwk.json");
+
+        // Mock JWKS endpoint returns all 3 keys
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET).path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(
+                    r#"{{"keys":[{}, {}, {}]}}"#,
+                    rs256_jwk, rs384_jwk, rs512_jwk
+                ));
+        });
+
+        // Pre-cached file contains ONLY rs256
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        std::fs::write(&path, format!(r#"{{"keys":[{}]}}"#, rs256_jwk)).unwrap();
+
+        let server_url = server.url("/");
+        let iss = server_url.clone();
+        let aud = "test-app";
+        let min_refresh_rate = Duration::try_seconds(600).unwrap();
+
+        let keys = KeysStorage::new(
+            Url::parse(&server_url).unwrap(),
+            min_refresh_rate,
+            Some(path),
+        );
+        let principal_id_claims = PrincipalIDClaims::from_comma_separated_values(
+            "preferred_username, sub",
+            "unknown".to_string(),
+        );
+        let accepted_issuers = AcceptedClaims::from_comma_separated_values(&iss, "iss".to_string());
+        let accepted_audiences =
+            AcceptedClaims::from_comma_separated_values(aud, "aud".to_string());
+        let accepted_signing_algorithms: AcceptedAlgorithms = Default::default();
+        let cel_validator: CelValidator = Default::default();
+        let mut handler = Handler::new(
+            Box::leak(Box::new(keys)),
+            Box::leak(Box::new(principal_id_claims)),
+            Box::leak(Box::new(accepted_issuers)),
+            Box::leak(Box::new(accepted_audiences)),
+            Box::leak(Box::new(accepted_signing_algorithms)),
+            Box::leak(Box::new(cel_validator)),
+        );
+
+        let exp = (Utc::now() + Duration::try_hours(1).unwrap()).timestamp();
+        let claims = json!({ "iss": iss, "aud": aud, "exp": exp, "sub": "user1", "preferred_username": "user1" });
+
+        // Token 1: signed with rs256 — key is in pre-warmed cache, no network call
+        let token1 = jsonwebtoken::encode(
+            &serde_json::from_value(json!({ "alg": "RS256", "kid": "test/keys/rs256/public" }))
+                .unwrap(),
+            &claims,
+            &EncodingKey::from_rsa_pem(
+                include_str!("../tests/fixtures/keys/rs256/private.pem").as_bytes(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let event = TokenAuthorizerEvent {
+            authorization_token: format!("Bearer {}", token1),
+            method_arn: "arn:aws:execute-api:us-east-1:123456789012:api/*/GET/".to_string(),
+        };
+        let response = handler
+            .call(LambdaEvent::new(event, Default::default()))
+            .await;
+        assert_eq!(
+            response.unwrap().policy_document.statement[0].effect,
+            "Allow"
+        );
+        jwks_mock.assert_calls(0);
+
+        // Token 2: signed with rs384 — cache miss, triggers network refresh
+        let token2 = jsonwebtoken::encode(
+            &serde_json::from_value(json!({ "alg": "RS384", "kid": "test/keys/rs384/public" }))
+                .unwrap(),
+            &claims,
+            &EncodingKey::from_rsa_pem(
+                include_str!("../tests/fixtures/keys/rs384/private.pem").as_bytes(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let event = TokenAuthorizerEvent {
+            authorization_token: format!("Bearer {}", token2),
+            method_arn: "arn:aws:execute-api:us-east-1:123456789012:api/*/GET/".to_string(),
+        };
+        let response = handler
+            .call(LambdaEvent::new(event, Default::default()))
+            .await;
+        assert_eq!(
+            response.unwrap().policy_document.statement[0].effect,
+            "Allow"
+        );
+        jwks_mock.assert_calls(1);
+
+        // Token 3: signed with rs512 — key already in cache from refresh, no new network call
+        let token3 = jsonwebtoken::encode(
+            &serde_json::from_value(json!({ "alg": "RS512", "kid": "test/keys/rs512/public" }))
+                .unwrap(),
+            &claims,
+            &EncodingKey::from_rsa_pem(
+                include_str!("../tests/fixtures/keys/rs512/private.pem").as_bytes(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let event = TokenAuthorizerEvent {
+            authorization_token: format!("Bearer {}", token3),
+            method_arn: "arn:aws:execute-api:us-east-1:123456789012:api/*/GET/".to_string(),
+        };
+        let response = handler
+            .call(LambdaEvent::new(event, Default::default()))
+            .await;
+        assert_eq!(
+            response.unwrap().policy_document.statement[0].effect,
+            "Allow"
+        );
+        jwks_mock.assert_calls(1); // still 1 — served from refreshed cache
+    }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,6 +11,7 @@ use futures_util::future::{BoxFuture, FutureExt};
 use jsonwebtoken::{decode, decode_header, Validation};
 use lambda_runtime::{Error, LambdaEvent, Service};
 use std::task::{Context, Poll};
+use std::time::Instant;
 
 pub struct Handler {
     pub keys: &'static KeysStorage,
@@ -87,6 +88,7 @@ impl Handler {
             }
         };
 
+        let start_time = Instant::now();
         let mut validation = Validation::new(token_header.alg);
         validation.set_audience(&self.accepted_audiences.accepted_values());
         validation.set_issuer(&self.accepted_issuers.accepted_values());
@@ -97,7 +99,9 @@ impl Handler {
                 return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
             }
         };
+        tracing::info!("Token validation took: {:?}", start_time.elapsed());
 
+        let start_time = Instant::now();
         // CEL validation (if configured)
         if let Err(e) = self
             .cel_validator
@@ -110,10 +114,13 @@ impl Handler {
             );
             return Ok(TokenAuthorizerResponse::deny(&event.method_arn));
         }
+        tracing::info!("CEL validation took: {:?}", start_time.elapsed());
 
+        let start_time = Instant::now();
         let principal_id = self
             .principal_id_claims
             .get_principal_id_from_claims(&token_payload.claims);
+        tracing::info!("Principal ID extraction took: {:?}", start_time.elapsed());
 
         Ok(TokenAuthorizerResponse::allow(
             &principal_id,

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -76,7 +76,10 @@ impl KeysStorage {
             drop(read_guard);
         }
 
-        tracing::error!("Key not found in memory storage or cached JWKS file: {}", key_id);
+        tracing::error!(
+            "Key not found in memory storage or cached JWKS file: {}",
+            key_id
+        );
         Err(KeysStorageError::KeyNotFound(key_id.to_string()))
     }
 
@@ -315,7 +318,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_should_return_key_from_valid_jwks_cache_file(){
+    async fn it_should_return_key_from_valid_jwks_cache_file() {
         println!("it_should_return_key_from_valid_jwks_cache_file");
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -2,7 +2,7 @@ use crate::keysmap::KeysMap;
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{jwk::JwkSet, DecodingKey};
 use reqwest::{Client, Url};
-use std::{fs::File, io::Error, path::PathBuf, sync::Arc, time::Instant};
+use std::{fs::File, path::PathBuf, sync::Arc};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -20,9 +20,9 @@ pub enum KeysStorageError {
 pub struct KeysStorage {
     jwks_uri: Url,
     client: Client,
-    l1_cache: Arc<RwLock<(KeysMap, DateTime<Utc>)>>,
+    storage: Arc<RwLock<(KeysMap, DateTime<Utc>)>>,
     min_refresh_rate: Duration,
-    jwks_pre_cached_file_path: Option<PathBuf>,
+    pre_warmed: bool,
 }
 
 impl KeysStorage {
@@ -31,6 +31,33 @@ impl KeysStorage {
         min_refresh_rate: Duration,
         jwks_pre_cached_file_path: Option<PathBuf>,
     ) -> Self {
+        let (initial_keys, pre_warmed) = match jwks_pre_cached_file_path {
+            Some(ref path) => {
+                tracing::debug!(
+                    "Loading pre-cached JWKS from '{}'",
+                    path.as_path().display()
+                );
+                match File::open(path).and_then(|file| {
+                    serde_json::from_reader::<_, JwkSet>(file)
+                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+                }) {
+                    Ok(jwks) => {
+                        tracing::debug!("Pre-warmed JWKS cache with keys from file");
+                        (KeysMap::from(jwks), true)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to load pre-cached JWKS file '{}': {}. Starting with empty cache.",
+                            path.display(),
+                            e
+                        );
+                        (KeysMap::default(), false)
+                    }
+                }
+            }
+            None => (KeysMap::default(), false),
+        };
+
         Self {
             jwks_uri,
             min_refresh_rate,
@@ -38,65 +65,39 @@ impl KeysStorage {
                 .user_agent(format!("oidc-authorizer/{}", env!("CARGO_PKG_VERSION")))
                 .build()
                 .unwrap(),
-            l1_cache: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
-            jwks_pre_cached_file_path,
+            storage: Arc::new(RwLock::new((initial_keys, Default::default()))),
+            pre_warmed,
         }
     }
 
     pub async fn get(&self, key_id: &str) -> Result<DecodingKey, KeysStorageError> {
-        let start_time = Instant::now();
-        let read_guard = self.l1_cache.read().await;
-        let maybe_key = read_guard.0.get(key_id);
-        if let Some(key) = maybe_key {
-            tracing::info!("Key found in l1_cache, took: {:?}", start_time.elapsed());
+        let read_guard = self.storage.read().await;
+        if let Some(key) = read_guard.0.get(key_id) {
             return Ok(key.clone());
         }
 
-        // Is the memory storage expired? Determine this before we muddy the memory from L2.
         let should_refresh = read_guard.1 + self.min_refresh_rate < Utc::now();
-        drop(read_guard); // so that we can write to storage.
-
-        let start_time = Instant::now();
-        let res = self.maybe_load_from_l2_cache().await;
-        if res.is_ok() {
-            let read_guard = self.l1_cache.read().await;
-            let maybe_key = read_guard.0.get(key_id);
-            if let Some(key) = maybe_key {
-                tracing::info!("Key found in l2_cache, took: {:?}", start_time.elapsed());
-                return Ok(key.clone());
-            }
-        } else {
-            tracing::error!("Failed to load cached JWKS file: {}", res.err().unwrap());
-        }
+        drop(read_guard);
 
         if should_refresh {
-            let start_time = Instant::now();
             self.refresh().await?;
-            let read_guard = self.l1_cache.read().await;
-            let maybe_key = read_guard.0.get(key_id);
-            if let Some(key) = maybe_key {
-                tracing::info!("Key found in origin JWKS, took: {:?}", start_time.elapsed());
+            let read_guard = self.storage.read().await;
+            if let Some(key) = read_guard.0.get(key_id) {
+                if self.pre_warmed {
+                    tracing::warn!(
+                        event_type = "jwks_refresh_needed",
+                        jwks_uri = %self.jwks_uri,
+                        key_id = key_id,
+                        "Pre-warmed JWKS cache miss. Keys refreshed from JWKS endpoint. \
+                         Consider updating the pre-cached JWKS file."
+                    );
+                }
                 return Ok(key.clone());
             }
             drop(read_guard);
         }
 
         Err(KeysStorageError::KeyNotFound(key_id.to_string()))
-    }
-
-    async fn maybe_load_from_l2_cache(&self) -> Result<(), Error> {
-        if self.jwks_pre_cached_file_path.is_none() {
-            tracing::debug!("Invalid JWKS pre-cache file path. Skipping cache load from disk.");
-            return Ok(());
-        }
-        let path = self.jwks_pre_cached_file_path.as_ref().unwrap();
-        tracing::debug!("Loading cached JWKS from '{}'", path.as_path().display());
-        let file = File::open(path.as_path())?;
-        let jwks: JwkSet = serde_json::from_reader(file)?;
-        let mut write_guard = self.l1_cache.write().await;
-        write_guard.0 = jwks.into();
-        write_guard.1 = write_guard.1.min(Utc::now());
-        Ok(())
     }
 
     async fn refresh(&self) -> Result<(), KeysStorageError> {
@@ -107,7 +108,7 @@ impl KeysStorage {
         tracing::debug!("JWKS fetched got body: {}", jwks);
         let jwks: JwkSet = serde_json::from_str(&jwks)?;
 
-        let mut write_guard = self.l1_cache.write().await;
+        let mut write_guard = self.storage.write().await;
         write_guard.0 = jwks.into();
         write_guard.1 = Utc::now();
         Ok(())
@@ -132,7 +133,8 @@ mod tests {
 
         assert_eq!(keys_cache.jwks_uri, jwks_uri);
         assert_eq!(keys_cache.min_refresh_rate, min_refresh_rate);
-        assert_eq!(keys_cache.l1_cache.read().await.0.len(), 0);
+        assert_eq!(keys_cache.storage.read().await.0.len(), 0);
+        assert!(!keys_cache.pre_warmed);
     }
 
     #[tokio::test]
@@ -216,7 +218,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn it_should_not_error_if_the_cache_file_path_is_invalid() {
+    async fn it_should_fall_back_to_network_if_cache_file_path_is_invalid() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
             when.method(GET)
@@ -243,8 +245,9 @@ mod tests {
         let keys_cache = KeysStorage::new(
             jwks_uri.clone(),
             min_refresh_rate,
-            Some(PathBuf::from("invalid")),
+            Some(PathBuf::from("/nonexistent/path/jwks.json")),
         );
+        assert!(!keys_cache.pre_warmed);
         let key_result = keys_cache.get("test/keys/rs256/public").await;
         assert!(key_result.is_ok());
         jwks_mock.assert();
@@ -252,7 +255,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn it_should_not_return_an_error_if_the_cached_file_contains_invalid_json() {
+    async fn it_should_fall_back_to_network_if_cached_file_contains_invalid_json() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
             when.method(GET)
@@ -276,11 +279,11 @@ mod tests {
         });
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-        let keys_cache = KeysStorage::new(
-            jwks_uri.clone(),
-            min_refresh_rate,
-            Some(PathBuf::from("{{invalid")),
-        );
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        std::fs::write(&path, "{{not valid json").unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(path));
+        assert!(!keys_cache.pre_warmed);
         let key_result = keys_cache.get("test/keys/rs256/public").await;
         assert!(key_result.is_ok());
         jwks_mock.assert();
@@ -288,7 +291,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn it_should_handle_invalid_jwks_cached_file_by_falling_back_to_refetching_jwks() {
+    async fn it_should_fall_back_to_network_if_cached_file_has_wrong_schema() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
             when.method(GET)
@@ -312,7 +315,7 @@ mod tests {
         });
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         let file = NamedTempFile::new().unwrap();
-        let path = file.into_temp_path().to_path_buf();
+        let path = file.path().to_path_buf();
         let dynamic_json = json!({
             "something": "else",
             "array": [1, 2, 3]
@@ -320,6 +323,7 @@ mod tests {
         std::fs::write(&path, dynamic_json.to_string()).unwrap();
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
         let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(path));
+        assert!(!keys_cache.pre_warmed);
         let key_result = keys_cache.get("test/keys/rs256/public").await;
         assert!(key_result.is_ok());
         jwks_mock.assert();
@@ -327,35 +331,18 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn it_should_return_key_from_valid_jwks_cache_file() {
-        tracing::debug!("it_should_return_key_from_valid_jwks_cache_file");
+    async fn it_should_return_key_from_pre_warmed_cache_without_network_call() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/");
+            when.method(GET).path("/");
             then.status(200)
                 .header("content-type", "application/json")
-                .body(r#"
-                    {
-                        "keys":[
-                            {
-                                "kty":"RSA",
-                                "n":"0TF4RX87dOllFp12D8IZvSoJyp8D4IZ3JmlVG7Au2GOSp1WcrAqjyq3Gk-a_1tT31FHCLVqjH9vXE8g1sXika4mp8YCWyMfjT3KsfrciI_Fw-nBCawnqewBDcBo4cvBgTjHNBjcjGNr0U_4eCZPjP8pwqw6HrRgHf-ypNmtgWG6_2EaK-tOJtnNgGRtCYGZdqMDfKLDuqzU5-gT2ejt9P1kNAvFMMUm4dTOK-vJ7jwGKWZEzupHBlHMqu4K4IRoFbVr2XsAzV5YQ0u_r26NVtQTDUdTp9ixhexUp0eXye6m3uMklqUOHJbiqNjmH2ye4yXVJI0w6BFOeXXlwyR6slw",
-                                "e":"AQAB",
-                                "alg":"RS256",
-                                "kid":"test/keys/rs256/public",
-                                "use":"sig"
-                            }
-                        ]
-                    }
-                "#);
+                .body(r#"{"keys":[]}"#);
         });
-        tracing::debug!("server setup complete");
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         let file = NamedTempFile::new().unwrap();
         let path = file.path().to_path_buf();
-        tracing::debug!("path: {}", path.display());
-        let dynamic_json = json!({
+        let jwks_json = json!({
             "keys":[
                 {
                     "kty":"RSA",
@@ -367,19 +354,13 @@ mod tests {
                 }
             ]
         });
-        std::fs::write(path.clone(), dynamic_json.to_string()).unwrap();
-        tracing::debug!("file written to path: {}", path.display());
+        std::fs::write(&path, jwks_json.to_string()).unwrap();
 
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-
-        let start_time = Instant::now();
         let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(path));
-        tracing::debug!("keys_cache init took: {:?}", start_time.elapsed());
+        assert!(keys_cache.pre_warmed);
 
-        let start_time = Instant::now();
         let key_result = keys_cache.get("test/keys/rs256/public").await;
-        tracing::debug!("keys_cache get took: {:?}", start_time.elapsed());
-
         assert!(key_result.is_ok());
         jwks_mock.assert_calls(0);
     }

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -48,11 +48,7 @@ impl KeysStorage {
         let read_guard = self.l1_cache.read().await;
         let maybe_key = read_guard.0.get(key_id);
         if let Some(key) = maybe_key {
-            tracing::info!(
-                "Key found in memory storage: {} took: {:?}",
-                key_id,
-                start_time.elapsed()
-            );
+            tracing::info!("Key found in l1_cache, took: {:?}", start_time.elapsed());
             return Ok(key.clone());
         }
 
@@ -61,19 +57,12 @@ impl KeysStorage {
         drop(read_guard); // so that we can write to storage.
 
         let start_time = Instant::now();
-        let res = self.load_from_l2_cache().await;
-        tracing::info!("load_from_l2_cache took: {:?}", start_time.elapsed());
-
-        let start_time = Instant::now();
+        let res = self.maybe_load_from_l2_cache().await;
         if res.is_ok() {
             let read_guard = self.l1_cache.read().await;
             let maybe_key = read_guard.0.get(key_id);
             if let Some(key) = maybe_key {
-                tracing::info!(
-                    "Key found in cached JWKS file: {} took: {:?}",
-                    key_id,
-                    start_time.elapsed()
-                );
+                tracing::info!("Key found in l2_cache, took: {:?}", start_time.elapsed());
                 return Ok(key.clone());
             }
         } else {
@@ -86,20 +75,16 @@ impl KeysStorage {
             let read_guard = self.l1_cache.read().await;
             let maybe_key = read_guard.0.get(key_id);
             if let Some(key) = maybe_key {
-                tracing::info!("origin fetch took: {:?}", start_time.elapsed());
+                tracing::info!("Key found in origin JWKS, took: {:?}", start_time.elapsed());
                 return Ok(key.clone());
             }
             drop(read_guard);
         }
 
-        tracing::error!(
-            "Key not found in memory storage or cached JWKS file: {}",
-            key_id
-        );
         Err(KeysStorageError::KeyNotFound(key_id.to_string()))
     }
 
-    async fn load_from_l2_cache(&self) -> Result<(), Error> {
+    async fn maybe_load_from_l2_cache(&self) -> Result<(), Error> {
         if self.jwks_pre_cached_file_path.is_none() {
             tracing::debug!("Invalid JWKS pre-cache file path. Skipping cache load from disk.");
             return Ok(());

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -26,7 +26,11 @@ pub struct KeysStorage {
 }
 
 impl KeysStorage {
-    pub fn new(jwks_uri: Url, min_refresh_rate: Duration, jwks_pre_cached_file_path:Option<PathBuf>) -> Self {
+    pub fn new(
+        jwks_uri: Url,
+        min_refresh_rate: Duration,
+        jwks_pre_cached_file_path: Option<PathBuf>,
+    ) -> Self {
         Self {
             jwks_uri,
             min_refresh_rate,
@@ -50,21 +54,21 @@ impl KeysStorage {
 
                 let res = self.load_cached_file().await;
                 match res {
-                  Ok(_) => {
-                    let read_guard = self.storage.read().await;
-                    let maybe_key = read_guard.0.get(key_id);
-                    match maybe_key {
-                      Some(key) => return Ok(key.clone()),
-                      None => {
-                        tracing::error!("Key not found in cached JWKS file: {}", key_id);
-                        // continue to refresh the jwks
-                      }
+                    Ok(_) => {
+                        let read_guard = self.storage.read().await;
+                        let maybe_key = read_guard.0.get(key_id);
+                        match maybe_key {
+                            Some(key) => return Ok(key.clone()),
+                            None => {
+                                tracing::error!("Key not found in cached JWKS file: {}", key_id);
+                                // continue to refresh the jwks
+                            }
+                        }
                     }
-                  }
-                  Err(e) => {
-                    tracing::error!("Failed to load cached JWKS file: {}", e);
-                    // continue to refresh the jwks
-                  }
+                    Err(e) => {
+                        tracing::error!("Failed to load cached JWKS file: {}", e);
+                        // continue to refresh the jwks
+                    }
                 }
 
                 if should_refresh {

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -120,9 +120,9 @@ impl KeysStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use httpmock::{prelude::*};
-    use tempfile::NamedTempFile;
+    use httpmock::prelude::*;
     use serde_json::json;
+    use tempfile::NamedTempFile;
 
     #[tokio::test]
     async fn it_should_initialize_an_empty_instance() {
@@ -238,7 +238,11 @@ mod tests {
         });
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(PathBuf::from("invalid")));
+        let keys_cache = KeysStorage::new(
+            jwks_uri.clone(),
+            min_refresh_rate,
+            Some(PathBuf::from("invalid")),
+        );
         let key_result = keys_cache.get("test/keys/rs256/public").await;
         assert!(key_result.is_ok());
         jwks_mock.assert();
@@ -269,7 +273,11 @@ mod tests {
         });
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(PathBuf::from("{{invalid")));
+        let keys_cache = KeysStorage::new(
+            jwks_uri.clone(),
+            min_refresh_rate,
+            Some(PathBuf::from("{{invalid")),
+        );
         let key_result = keys_cache.get("test/keys/rs256/public").await;
         assert!(key_result.is_ok());
         jwks_mock.assert();

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -46,44 +46,37 @@ impl KeysStorage {
     pub async fn get(&self, key_id: &str) -> Result<DecodingKey, KeysStorageError> {
         let read_guard = self.storage.read().await;
         let maybe_key = read_guard.0.get(key_id);
-        match maybe_key {
-            Some(key) => return Ok(key.clone()),
-            None => {
-                // Is the memory storage expired? Determine this before we muddy the memory from L2.
-                let should_refresh = read_guard.1 + self.min_refresh_rate < Utc::now();
+        if let Some(key) = maybe_key {
+            tracing::debug!("Key found in memory storage: {}", key_id);
+            return Ok(key.clone());
+        }
 
-                let res = self.load_cached_file().await;
-                match res {
-                    Ok(_) => {
-                        let read_guard = self.storage.read().await;
-                        let maybe_key = read_guard.0.get(key_id);
-                        match maybe_key {
-                            Some(key) => return Ok(key.clone()),
-                            None => {
-                                tracing::error!("Key not found in cached JWKS file: {}", key_id);
-                                // continue to refresh the jwks
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("Failed to load cached JWKS file: {}", e);
-                        // continue to refresh the jwks
-                    }
-                }
+        // Is the memory storage expired? Determine this before we muddy the memory from L2.
+        let should_refresh = read_guard.1 + self.min_refresh_rate < Utc::now();
+        drop(read_guard); // so that we can write to storage.
 
-                if should_refresh {
-                    drop(read_guard);
-                    self.refresh().await?;
-                    let read_guard = self.storage.read().await;
-                    let maybe_key = read_guard.0.get(key_id);
-                    if let Some(key) = maybe_key {
-                        return Ok(key.clone());
-                    }
-                    drop(read_guard);
-                }
+        let res = self.load_cached_file().await;
+        if res.is_ok() {
+            let read_guard = self.storage.read().await;
+            let maybe_key = read_guard.0.get(key_id);
+            if let Some(key) = maybe_key {
+                tracing::debug!("Key found in cached JWKS file: {}", key_id);
+                return Ok(key.clone());
             }
-        };
+        }
 
+        if should_refresh {
+            tracing::debug!("Refreshing JWKS from origin.");
+            self.refresh().await?;
+            let read_guard = self.storage.read().await;
+            let maybe_key = read_guard.0.get(key_id);
+            if let Some(key) = maybe_key {
+                return Ok(key.clone());
+            }
+            drop(read_guard);
+        }
+
+        tracing::error!("Key not found in memory storage or cached JWKS file: {}", key_id);
         Err(KeysStorageError::KeyNotFound(key_id.to_string()))
     }
 
@@ -319,5 +312,58 @@ mod tests {
         let key_result = keys_cache.get("test/keys/rs256/public").await;
         assert!(key_result.is_ok());
         jwks_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn it_should_return_key_from_valid_jwks_cache_file(){
+        println!("it_should_return_key_from_valid_jwks_cache_file");
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"
+                    {
+                        "keys":[
+                            {
+                                "kty":"RSA",
+                                "n":"0TF4RX87dOllFp12D8IZvSoJyp8D4IZ3JmlVG7Au2GOSp1WcrAqjyq3Gk-a_1tT31FHCLVqjH9vXE8g1sXika4mp8YCWyMfjT3KsfrciI_Fw-nBCawnqewBDcBo4cvBgTjHNBjcjGNr0U_4eCZPjP8pwqw6HrRgHf-ypNmtgWG6_2EaK-tOJtnNgGRtCYGZdqMDfKLDuqzU5-gT2ejt9P1kNAvFMMUm4dTOK-vJ7jwGKWZEzupHBlHMqu4K4IRoFbVr2XsAzV5YQ0u_r26NVtQTDUdTp9ixhexUp0eXye6m3uMklqUOHJbiqNjmH2ye4yXVJI0w6BFOeXXlwyR6slw",
+                                "e":"AQAB",
+                                "alg":"RS256",
+                                "kid":"test/keys/rs256/public",
+                                "use":"sig"
+                            }
+                        ]
+                    }
+                "#);
+        });
+        println!("server setup complete");
+        let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        println!("path: {}", path.display());
+        let dynamic_json = json!({
+            "keys":[
+                {
+                    "kty":"RSA",
+                    "n":"0TF4RX87dOllFp12D8IZvSoJyp8D4IZ3JmlVG7Au2GOSp1WcrAqjyq3Gk-a_1tT31FHCLVqjH9vXE8g1sXika4mp8YCWyMfjT3KsfrciI_Fw-nBCawnqewBDcBo4cvBgTjHNBjcjGNr0U_4eCZPjP8pwqw6HrRgHf-ypNmtgWG6_2EaK-tOJtnNgGRtCYGZdqMDfKLDuqzU5-gT2ejt9P1kNAvFMMUm4dTOK-vJ7jwGKWZEzupHBlHMqu4K4IRoFbVr2XsAzV5YQ0u_r26NVtQTDUdTp9ixhexUp0eXye6m3uMklqUOHJbiqNjmH2ye4yXVJI0w6BFOeXXlwyR6slw",
+                    "e":"AQAB",
+                    "alg":"RS256",
+                    "kid":"test/keys/rs256/public",
+                    "use":"sig"
+                }
+            ]
+        });
+        std::fs::write(path.clone(), dynamic_json.to_string()).unwrap();
+        println!("file written to path: {}", path.display());
+
+        let min_refresh_rate = Duration::try_seconds(60).unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(path));
+        println!("keys_cache created");
+        let key_result = keys_cache.get("test/keys/rs256/public").await;
+        println!("key_result");
+        assert!(key_result.is_ok());
+        jwks_mock.assert_calls(0);
     }
 }

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -2,7 +2,7 @@ use crate::keysmap::KeysMap;
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{jwk::JwkSet, DecodingKey};
 use reqwest::{Client, Url};
-use std::sync::Arc;
+use std::{fs::File, io::Error, path::PathBuf, sync::Arc};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -22,10 +22,11 @@ pub struct KeysStorage {
     client: Client,
     storage: Arc<RwLock<(KeysMap, DateTime<Utc>)>>,
     min_refresh_rate: Duration,
+    jwks_pre_cached_file_path: Option<PathBuf>,
 }
 
 impl KeysStorage {
-    pub fn new(jwks_uri: Url, min_refresh_rate: Duration) -> Self {
+    pub fn new(jwks_uri: Url, min_refresh_rate: Duration, jwks_pre_cached_file_path:Option<PathBuf>) -> Self {
         Self {
             jwks_uri,
             min_refresh_rate,
@@ -34,6 +35,7 @@ impl KeysStorage {
                 .build()
                 .unwrap(),
             storage: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
+            jwks_pre_cached_file_path,
         }
     }
 
@@ -43,7 +45,28 @@ impl KeysStorage {
         match maybe_key {
             Some(key) => return Ok(key.clone()),
             None => {
+                // Is the memory storage expired? Determine this before we muddy the memory from L2.
                 let should_refresh = read_guard.1 + self.min_refresh_rate < Utc::now();
+
+                let res = self.load_cached_file().await;
+                match res {
+                  Ok(_) => {
+                    let read_guard = self.storage.read().await;
+                    let maybe_key = read_guard.0.get(key_id);
+                    match maybe_key {
+                      Some(key) => return Ok(key.clone()),
+                      None => {
+                        tracing::error!("Key not found in cached JWKS file: {}", key_id);
+                        // continue to refresh the jwks
+                      }
+                    }
+                  }
+                  Err(e) => {
+                    tracing::error!("Failed to load cached JWKS file: {}", e);
+                    // continue to refresh the jwks
+                  }
+                }
+
                 if should_refresh {
                     drop(read_guard);
                     self.refresh().await?;
@@ -58,6 +81,21 @@ impl KeysStorage {
         };
 
         Err(KeysStorageError::KeyNotFound(key_id.to_string()))
+    }
+
+    async fn load_cached_file(&self) -> Result<(), Error> {
+        if self.jwks_pre_cached_file_path.is_none() {
+            tracing::debug!("Invalid JWKS pre-cache file path. Skipping cache load from disk.");
+            return Ok(());
+        }
+        let path = self.jwks_pre_cached_file_path.as_ref().unwrap();
+        tracing::debug!("Loading cached JWKS from '{}'", path.as_path().display());
+        let file = File::open(path.as_path())?;
+        let jwks: JwkSet = serde_json::from_reader(file)?;
+        let mut write_guard = self.storage.write().await;
+        write_guard.0 = jwks.into();
+        write_guard.1 = write_guard.1.min(Utc::now());
+        Ok(())
     }
 
     async fn refresh(&self) -> Result<(), KeysStorageError> {
@@ -85,7 +123,7 @@ mod tests {
         let jwks_uri = Url::parse("https://example.com/jwks.json").unwrap();
         // SAFETY: safe to unwrap since (60 seconds) <= (i64::MAX / 1000)
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate);
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, None);
 
         assert_eq!(keys_cache.jwks_uri, jwks_uri);
         assert_eq!(keys_cache.min_refresh_rate, min_refresh_rate);
@@ -112,7 +150,7 @@ mod tests {
                                 "use":"sig"
                             }
                         ]
-                    }            
+                    }
                 "#);
         });
 
@@ -120,7 +158,7 @@ mod tests {
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         // SAFETY: safe to unwrap since (60 seconds) <= (i64::MAX / 1000)
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate);
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, None);
         let key_result = keys_cache.get(key_id).await;
         assert!(key_result.is_ok());
         jwks_mock.assert_calls(1);
@@ -151,7 +189,7 @@ mod tests {
                                 "use":"sig"
                             }
                         ]
-                    }            
+                    }
                 "#);
         });
 
@@ -159,7 +197,7 @@ mod tests {
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         // SAFETY: safe to unwrap since (60 seconds) <= (i64::MAX / 1000)
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
-        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate);
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, None);
         let key_result = keys_cache.get(key_id).await;
         if let Err(KeysStorageError::KeyNotFound(_)) = key_result {
             // expected

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -20,7 +20,7 @@ pub enum KeysStorageError {
 pub struct KeysStorage {
     jwks_uri: Url,
     client: Client,
-    storage: Arc<RwLock<(KeysMap, DateTime<Utc>)>>,
+    l1_cache: Arc<RwLock<(KeysMap, DateTime<Utc>)>>,
     min_refresh_rate: Duration,
     jwks_pre_cached_file_path: Option<PathBuf>,
 }
@@ -38,13 +38,13 @@ impl KeysStorage {
                 .user_agent(format!("oidc-authorizer/{}", env!("CARGO_PKG_VERSION")))
                 .build()
                 .unwrap(),
-            storage: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
+            l1_cache: Arc::new(RwLock::new((KeysMap::default(), Default::default()))),
             jwks_pre_cached_file_path,
         }
     }
 
     pub async fn get(&self, key_id: &str) -> Result<DecodingKey, KeysStorageError> {
-        let read_guard = self.storage.read().await;
+        let read_guard = self.l1_cache.read().await;
         let maybe_key = read_guard.0.get(key_id);
         if let Some(key) = maybe_key {
             tracing::debug!("Key found in memory storage: {}", key_id);
@@ -55,20 +55,22 @@ impl KeysStorage {
         let should_refresh = read_guard.1 + self.min_refresh_rate < Utc::now();
         drop(read_guard); // so that we can write to storage.
 
-        let res = self.load_cached_file().await;
+        let res = self.load_from_l2_cache().await;
         if res.is_ok() {
-            let read_guard = self.storage.read().await;
+            let read_guard = self.l1_cache.read().await;
             let maybe_key = read_guard.0.get(key_id);
             if let Some(key) = maybe_key {
                 tracing::debug!("Key found in cached JWKS file: {}", key_id);
                 return Ok(key.clone());
             }
+        } else {
+            tracing::error!("Failed to load cached JWKS file: {}", res.err().unwrap());
         }
 
         if should_refresh {
             tracing::debug!("Refreshing JWKS from origin.");
             self.refresh().await?;
-            let read_guard = self.storage.read().await;
+            let read_guard = self.l1_cache.read().await;
             let maybe_key = read_guard.0.get(key_id);
             if let Some(key) = maybe_key {
                 return Ok(key.clone());
@@ -83,7 +85,7 @@ impl KeysStorage {
         Err(KeysStorageError::KeyNotFound(key_id.to_string()))
     }
 
-    async fn load_cached_file(&self) -> Result<(), Error> {
+    async fn load_from_l2_cache(&self) -> Result<(), Error> {
         if self.jwks_pre_cached_file_path.is_none() {
             tracing::debug!("Invalid JWKS pre-cache file path. Skipping cache load from disk.");
             return Ok(());
@@ -92,7 +94,7 @@ impl KeysStorage {
         tracing::debug!("Loading cached JWKS from '{}'", path.as_path().display());
         let file = File::open(path.as_path())?;
         let jwks: JwkSet = serde_json::from_reader(file)?;
-        let mut write_guard = self.storage.write().await;
+        let mut write_guard = self.l1_cache.write().await;
         write_guard.0 = jwks.into();
         write_guard.1 = write_guard.1.min(Utc::now());
         Ok(())
@@ -106,7 +108,7 @@ impl KeysStorage {
         tracing::debug!("JWKS fetched got body: {}", jwks);
         let jwks: JwkSet = serde_json::from_str(&jwks)?;
 
-        let mut write_guard = self.storage.write().await;
+        let mut write_guard = self.l1_cache.write().await;
         write_guard.0 = jwks.into();
         write_guard.1 = Utc::now();
         Ok(())
@@ -129,7 +131,7 @@ mod tests {
 
         assert_eq!(keys_cache.jwks_uri, jwks_uri);
         assert_eq!(keys_cache.min_refresh_rate, min_refresh_rate);
-        assert_eq!(keys_cache.storage.read().await.0.len(), 0);
+        assert_eq!(keys_cache.l1_cache.read().await.0.len(), 0);
     }
 
     #[tokio::test]

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -120,7 +120,9 @@ impl KeysStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use httpmock::prelude::*;
+    use httpmock::{prelude::*};
+    use tempfile::NamedTempFile;
+    use serde_json::json;
 
     #[tokio::test]
     async fn it_should_initialize_an_empty_instance() {
@@ -196,7 +198,6 @@ mod tests {
                     }
                 "#);
         });
-
         let key_id = "invalid";
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         // SAFETY: safe to unwrap since (60 seconds) <= (i64::MAX / 1000)
@@ -209,6 +210,106 @@ mod tests {
             panic!("Expected a KeyNotFound error");
         }
 
+        jwks_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn it_should_not_error_if_the_cache_file_path_is_invalid() {
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"
+                    {
+                        "keys":[
+                            {
+                                "kty":"RSA",
+                                "n":"0TF4RX87dOllFp12D8IZvSoJyp8D4IZ3JmlVG7Au2GOSp1WcrAqjyq3Gk-a_1tT31FHCLVqjH9vXE8g1sXika4mp8YCWyMfjT3KsfrciI_Fw-nBCawnqewBDcBo4cvBgTjHNBjcjGNr0U_4eCZPjP8pwqw6HrRgHf-ypNmtgWG6_2EaK-tOJtnNgGRtCYGZdqMDfKLDuqzU5-gT2ejt9P1kNAvFMMUm4dTOK-vJ7jwGKWZEzupHBlHMqu4K4IRoFbVr2XsAzV5YQ0u_r26NVtQTDUdTp9ixhexUp0eXye6m3uMklqUOHJbiqNjmH2ye4yXVJI0w6BFOeXXlwyR6slw",
+                                "e":"AQAB",
+                                "alg":"RS256",
+                                "kid":"test/keys/rs256/public",
+                                "use":"sig"
+                            }
+                        ]
+                    }
+                "#);
+        });
+        let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
+        let min_refresh_rate = Duration::try_seconds(60).unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(PathBuf::from("invalid")));
+        let key_result = keys_cache.get("test/keys/rs256/public").await;
+        assert!(key_result.is_ok());
+        jwks_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn it_should_not_return_an_error_if_the_cached_file_contains_invalid_json() {
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"
+                    {
+                        "keys":[
+                            {
+                                "kty":"RSA",
+                                "n":"0TF4RX87dOllFp12D8IZvSoJyp8D4IZ3JmlVG7Au2GOSp1WcrAqjyq3Gk-a_1tT31FHCLVqjH9vXE8g1sXika4mp8YCWyMfjT3KsfrciI_Fw-nBCawnqewBDcBo4cvBgTjHNBjcjGNr0U_4eCZPjP8pwqw6HrRgHf-ypNmtgWG6_2EaK-tOJtnNgGRtCYGZdqMDfKLDuqzU5-gT2ejt9P1kNAvFMMUm4dTOK-vJ7jwGKWZEzupHBlHMqu4K4IRoFbVr2XsAzV5YQ0u_r26NVtQTDUdTp9ixhexUp0eXye6m3uMklqUOHJbiqNjmH2ye4yXVJI0w6BFOeXXlwyR6slw",
+                                "e":"AQAB",
+                                "alg":"RS256",
+                                "kid":"test/keys/rs256/public",
+                                "use":"sig"
+                            }
+                        ]
+                    }
+                "#);
+        });
+        let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
+        let min_refresh_rate = Duration::try_seconds(60).unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(PathBuf::from("{{invalid")));
+        let key_result = keys_cache.get("test/keys/rs256/public").await;
+        assert!(key_result.is_ok());
+        jwks_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn it_should_handle_invalid_jwks_cached_file_by_falling_back_to_refetching_jwks() {
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"
+                    {
+                        "keys":[
+                            {
+                                "kty":"RSA",
+                                "n":"0TF4RX87dOllFp12D8IZvSoJyp8D4IZ3JmlVG7Au2GOSp1WcrAqjyq3Gk-a_1tT31FHCLVqjH9vXE8g1sXika4mp8YCWyMfjT3KsfrciI_Fw-nBCawnqewBDcBo4cvBgTjHNBjcjGNr0U_4eCZPjP8pwqw6HrRgHf-ypNmtgWG6_2EaK-tOJtnNgGRtCYGZdqMDfKLDuqzU5-gT2ejt9P1kNAvFMMUm4dTOK-vJ7jwGKWZEzupHBlHMqu4K4IRoFbVr2XsAzV5YQ0u_r26NVtQTDUdTp9ixhexUp0eXye6m3uMklqUOHJbiqNjmH2ye4yXVJI0w6BFOeXXlwyR6slw",
+                                "e":"AQAB",
+                                "alg":"RS256",
+                                "kid":"test/keys/rs256/public",
+                                "use":"sig"
+                            }
+                        ]
+                    }
+                "#);
+        });
+        let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
+        let file = NamedTempFile::new().unwrap();
+        let path = file.into_temp_path().to_path_buf();
+        let dynamic_json = json!({
+            "something": "else",
+            "array": [1, 2, 3]
+        });
+        std::fs::write(&path, dynamic_json.to_string()).unwrap();
+        let min_refresh_rate = Duration::try_seconds(60).unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(path));
+        let key_result = keys_cache.get("test/keys/rs256/public").await;
+        assert!(key_result.is_ok());
         jwks_mock.assert();
     }
 }

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -364,4 +364,76 @@ mod tests {
         assert!(key_result.is_ok());
         jwks_mock.assert_calls(0);
     }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn it_should_pre_warm_then_refresh_on_miss_then_serve_remaining_from_cache() {
+        let rs256_jwk = include_str!("../tests/fixtures/keys/rs256/jwk.json");
+        let rs384_jwk = include_str!("../tests/fixtures/keys/rs384/jwk.json");
+        let rs512_jwk = include_str!("../tests/fixtures/keys/rs512/jwk.json");
+
+        // Mock JWKS endpoint returns all 3 keys
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET).path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(
+                    r#"{{"keys":[{}, {}, {}]}}"#,
+                    rs256_jwk, rs384_jwk, rs512_jwk
+                ));
+        });
+
+        // Pre-cached file contains ONLY rs256 (key1)
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+        std::fs::write(&path, format!(r#"{{"keys":[{}]}}"#, rs256_jwk)).unwrap();
+
+        let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
+        let min_refresh_rate = Duration::try_seconds(600).unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri, min_refresh_rate, Some(path));
+        assert!(keys_cache.pre_warmed);
+
+        // Step 1: key1 (rs256) — should be served from pre-warmed cache, no network call
+        let result = keys_cache.get("test/keys/rs256/public").await;
+        assert!(result.is_ok());
+        jwks_mock.assert_calls(0);
+
+        // Step 2: key2 (rs384) — cache miss, triggers network refresh
+        let result = keys_cache.get("test/keys/rs384/public").await;
+        assert!(result.is_ok());
+        jwks_mock.assert_calls(1);
+        assert!(logs_contain("jwks_refresh_needed"));
+
+        // Step 3: key3 (rs512) — should already be in cache from step 2's refresh
+        let result = keys_cache.get("test/keys/rs512/public").await;
+        assert!(result.is_ok());
+        jwks_mock.assert_calls(1); // no additional network call
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn it_should_not_emit_refresh_event_without_pre_warming() {
+        let rs256_jwk = include_str!("../tests/fixtures/keys/rs256/jwk.json");
+
+        let server = MockServer::start();
+        let jwks_mock = server.mock(|when, then| {
+            when.method(GET).path("/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"keys":[{}]}}"#, rs256_jwk));
+        });
+
+        // No pre-cached file
+        let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
+        let min_refresh_rate = Duration::try_seconds(60).unwrap();
+        let keys_cache = KeysStorage::new(jwks_uri, min_refresh_rate, None);
+        assert!(!keys_cache.pre_warmed);
+
+        // Cache miss triggers network refresh, but no refresh event
+        let result = keys_cache.get("test/keys/rs256/public").await;
+        assert!(result.is_ok());
+        jwks_mock.assert_calls(1);
+        assert!(!logs_contain("jwks_refresh_needed"));
+    }
 }

--- a/src/keys_storage.rs
+++ b/src/keys_storage.rs
@@ -2,7 +2,7 @@ use crate::keysmap::KeysMap;
 use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{jwk::JwkSet, DecodingKey};
 use reqwest::{Client, Url};
-use std::{fs::File, io::Error, path::PathBuf, sync::Arc};
+use std::{fs::File, io::Error, path::PathBuf, sync::Arc, time::Instant};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -44,10 +44,15 @@ impl KeysStorage {
     }
 
     pub async fn get(&self, key_id: &str) -> Result<DecodingKey, KeysStorageError> {
+        let start_time = Instant::now();
         let read_guard = self.l1_cache.read().await;
         let maybe_key = read_guard.0.get(key_id);
         if let Some(key) = maybe_key {
-            tracing::debug!("Key found in memory storage: {}", key_id);
+            tracing::info!(
+                "Key found in memory storage: {} took: {:?}",
+                key_id,
+                start_time.elapsed()
+            );
             return Ok(key.clone());
         }
 
@@ -55,12 +60,20 @@ impl KeysStorage {
         let should_refresh = read_guard.1 + self.min_refresh_rate < Utc::now();
         drop(read_guard); // so that we can write to storage.
 
+        let start_time = Instant::now();
         let res = self.load_from_l2_cache().await;
+        tracing::info!("load_from_l2_cache took: {:?}", start_time.elapsed());
+
+        let start_time = Instant::now();
         if res.is_ok() {
             let read_guard = self.l1_cache.read().await;
             let maybe_key = read_guard.0.get(key_id);
             if let Some(key) = maybe_key {
-                tracing::debug!("Key found in cached JWKS file: {}", key_id);
+                tracing::info!(
+                    "Key found in cached JWKS file: {} took: {:?}",
+                    key_id,
+                    start_time.elapsed()
+                );
                 return Ok(key.clone());
             }
         } else {
@@ -68,11 +81,12 @@ impl KeysStorage {
         }
 
         if should_refresh {
-            tracing::debug!("Refreshing JWKS from origin.");
+            let start_time = Instant::now();
             self.refresh().await?;
             let read_guard = self.l1_cache.read().await;
             let maybe_key = read_guard.0.get(key_id);
             if let Some(key) = maybe_key {
+                tracing::info!("origin fetch took: {:?}", start_time.elapsed());
                 return Ok(key.clone());
             }
             drop(read_guard);
@@ -121,8 +135,10 @@ mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
     use tempfile::NamedTempFile;
+    use tracing_test::traced_test;
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_initialize_an_empty_instance() {
         let jwks_uri = Url::parse("https://example.com/jwks.json").unwrap();
         // SAFETY: safe to unwrap since (60 seconds) <= (i64::MAX / 1000)
@@ -135,6 +151,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_referesh_the_cache_when_retrieving_the_first_key() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
@@ -174,6 +191,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_return_an_error_if_the_key_is_not_found() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
@@ -212,6 +230,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_not_error_if_the_cache_file_path_is_invalid() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
@@ -247,6 +266,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_not_return_an_error_if_the_cached_file_contains_invalid_json() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
@@ -282,6 +302,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_handle_invalid_jwks_cached_file_by_falling_back_to_refetching_jwks() {
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
@@ -320,8 +341,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn it_should_return_key_from_valid_jwks_cache_file() {
-        println!("it_should_return_key_from_valid_jwks_cache_file");
+        tracing::debug!("it_should_return_key_from_valid_jwks_cache_file");
         let server = MockServer::start();
         let jwks_mock = server.mock(|when, then| {
             when.method(GET)
@@ -343,11 +365,11 @@ mod tests {
                     }
                 "#);
         });
-        println!("server setup complete");
+        tracing::debug!("server setup complete");
         let jwks_uri = Url::parse(server.url("/").as_str()).unwrap();
         let file = NamedTempFile::new().unwrap();
         let path = file.path().to_path_buf();
-        println!("path: {}", path.display());
+        tracing::debug!("path: {}", path.display());
         let dynamic_json = json!({
             "keys":[
                 {
@@ -361,13 +383,18 @@ mod tests {
             ]
         });
         std::fs::write(path.clone(), dynamic_json.to_string()).unwrap();
-        println!("file written to path: {}", path.display());
+        tracing::debug!("file written to path: {}", path.display());
 
         let min_refresh_rate = Duration::try_seconds(60).unwrap();
+
+        let start_time = Instant::now();
         let keys_cache = KeysStorage::new(jwks_uri.clone(), min_refresh_rate, Some(path));
-        println!("keys_cache created");
+        tracing::debug!("keys_cache init took: {:?}", start_time.elapsed());
+
+        let start_time = Instant::now();
         let key_result = keys_cache.get("test/keys/rs256/public").await;
-        println!("key_result");
+        tracing::debug!("keys_cache get took: {:?}", start_time.elapsed());
+
         assert!(key_result.is_ok());
         jwks_mock.assert_calls(0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use lambda_runtime::{run, tracing, Error};
 use principalid_claims::PrincipalIDClaims;
 use reqwest::Url;
 use std::{env, path::PathBuf};
+
 mod accepted_algorithms;
 mod accepted_claims;
 mod cel_validation;
@@ -54,7 +55,12 @@ async fn main() -> Result<(), Error> {
     let token_validation_cel = env::var("TOKEN_VALIDATION_CEL").unwrap_or_default();
     let cel_validator: CelValidator = token_validation_cel.parse()?;
 
-    tracing::init_default_subscriber();
+    let (writer, log_guard) = tracing_appender::non_blocking(std::io::stdout());
+    tracing::init_default_subscriber_with_writer(writer);
+    let shutdown_hook = || async move {
+        std::mem::drop(log_guard);
+    };
+    lambda_runtime::spawn_graceful_shutdown_handler(shutdown_hook).await;
 
     let keys = KeysStorage::new(jwks_uri, min_refresh_rate, jwks_pre_cached_file_path);
     run(handler::Handler::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,9 @@ mod parse_token_from_header;
 mod principalid_claims;
 
 fn maybe_get_jwks_cache_path() -> Option<PathBuf> {
-  env::var("JWKS_PRE_CACHED_FILE_PATH").ok().map(|path| PathBuf::from(path))
+    env::var("JWKS_PRE_CACHED_FILE_PATH")
+        .ok()
+        .map(|path| PathBuf::from(path))
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,12 +55,7 @@ async fn main() -> Result<(), Error> {
     let token_validation_cel = env::var("TOKEN_VALIDATION_CEL").unwrap_or_default();
     let cel_validator: CelValidator = token_validation_cel.parse()?;
 
-    let (writer, log_guard) = tracing_appender::non_blocking(std::io::stdout());
-    tracing::init_default_subscriber_with_writer(writer);
-    let shutdown_hook = || async move {
-        std::mem::drop(log_guard);
-    };
-    lambda_runtime::spawn_graceful_shutdown_handler(shutdown_hook).await;
+    tracing::init_default_subscriber();
 
     let keys = KeysStorage::new(jwks_uri, min_refresh_rate, jwks_pre_cached_file_path);
     run(handler::Handler::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ mod principalid_claims;
 fn maybe_get_jwks_cache_path() -> Option<PathBuf> {
     env::var("JWKS_PRE_CACHED_FILE_PATH")
         .ok()
-        .map(|path| PathBuf::from(path))
+        .map(PathBuf::from)
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use keys_storage::KeysStorage;
 use lambda_runtime::{run, tracing, Error};
 use principalid_claims::PrincipalIDClaims;
 use reqwest::Url;
-use std::env;
+use std::{env, path::PathBuf};
 mod accepted_algorithms;
 mod accepted_claims;
 mod cel_validation;
@@ -16,6 +16,10 @@ mod keysmap;
 mod models;
 mod parse_token_from_header;
 mod principalid_claims;
+
+fn maybe_get_jwks_cache_path() -> Option<PathBuf> {
+  env::var("JWKS_PRE_CACHED_FILE_PATH").ok().map(|path| PathBuf::from(path))
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -28,6 +32,8 @@ async fn main() -> Result<(), Error> {
             min_refresh_rate,
             i64::MAX / 1000
         ))?;
+
+    let jwks_pre_cached_file_path = maybe_get_jwks_cache_path();
     let principal_id_claims =
         env::var("PRINCIPAL_ID_CLAIMS").unwrap_or("preferred_username, sub".to_string());
     let default_principal_id = env::var("DEFAULT_PRINCIPAL_ID").unwrap_or("unknown".to_string());
@@ -48,7 +54,7 @@ async fn main() -> Result<(), Error> {
 
     tracing::init_default_subscriber();
 
-    let keys = KeysStorage::new(jwks_uri, min_refresh_rate);
+    let keys = KeysStorage::new(jwks_uri, min_refresh_rate, jwks_pre_cached_file_path);
     run(handler::Handler::new(
         Box::leak(Box::new(keys)),
         Box::leak(Box::new(principal_id_claims)),

--- a/template.yml
+++ b/template.yml
@@ -22,10 +22,19 @@ Parameters:
     Type: String
     Description: The minumum number of seconds to wait before keys are refreshed when the given key is not found.
     Default: "900" # 15 minutes
+  JwksPreCachedFilePath:
+    Type: String
+    Description: |
+      Optional path to a pre-cached JWKS file on disk. If specified, the authorizer will attempt to load keys from this file
+      before fetching from the JWKS URI endpoint. This can improve cold start performance by avoiding the initial network call.
+      The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format. If the file is invalid or
+      missing, the authorizer will gracefully fall back to fetching from the JWKS URI endpoint. The file path should be
+      accessible from the Lambda execution environment (e.g., /opt/ for Lambda layers, or relative to the Lambda package root).
+    Default: ""
   PrincipalIdClaims:
     Type: String
     Description: |
-      A comma-separated list of claims defining the token fields that should be used to determine the principal Id 
+      A comma-separated list of claims defining the token fields that should be used to determine the principal Id
       from the token. The fields will be tested in order. If there's no match the value specified in the `DefaultPrincipalId`
       parameter will be used.
     Default: "preferred_username, sub"
@@ -158,6 +167,7 @@ Conditions:
   ConfigureLogging: !Or
     - !Condition UseCustomLogGroup
     - !Condition CreateManagedLogGroup
+  HasJwksPreCachedFilePath: !Not [!Equals [!Ref JwksPreCachedFilePath, ""]]
 
 Resources:
   OidcAuthorizerLogGroup:
@@ -191,6 +201,10 @@ Resources:
           AWS_LAMBDA_LOG_LEVEL: !Ref AwsLambdaLogLevel
           JWKS_URI: !Ref JwksUri
           MIN_REFRESH_RATE: !Ref MinRefreshRate
+          JWKS_PRE_CACHED_FILE_PATH: !If
+            - HasJwksPreCachedFilePath
+            - !Ref JwksPreCachedFilePath
+            - !Ref "AWS::NoValue"
           PRINCIPAL_ID_CLAIMS: !Ref PrincipalIdClaims
           DEFAULT_PRINCIPAL_ID: !Ref DefaultPrincipalId
           ACCEPTED_ISSUERS: !Ref AcceptedIssuers

--- a/template.yml
+++ b/template.yml
@@ -25,11 +25,18 @@ Parameters:
   JwksPreCachedFilePath:
     Type: String
     Description: |
-      Optional path to a pre-cached JWKS file on disk. If specified, the authorizer will attempt to load keys from this file
-      before fetching from the JWKS URI endpoint. This can improve cold start performance by avoiding the initial network call.
-      The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format. If the file is invalid or
-      missing, the authorizer will gracefully fall back to fetching from the JWKS URI endpoint. The file path should be
-      accessible from the Lambda execution environment (e.g., /opt/ for Lambda layers, or relative to the Lambda package root).
+      Optional path to a pre-cached JWKS file on disk. When set, the authorizer pre-warms its in-memory key cache from this
+      file at startup, avoiding the initial network call to the JWKS endpoint. The file should contain a valid JWKS JSON
+      structure matching your OIDC provider's JWKS format. If the file is missing or invalid, the authorizer logs a warning
+      and starts with an empty cache (falling back to fetching from the JWKS URI on the first request). The file path should
+      be accessible from the Lambda execution environment (e.g., /opt/jwks.json for Lambda layers).
+    Default: ""
+  LambdaLayers:
+    Type: String
+    Description: |
+      Optional comma-separated list of Lambda layer ARNs to attach to the authorizer function.
+      Use this to add a pre-cached JWKS layer (for faster cold starts, together with JwksPreCachedFilePath),
+      monitoring extensions, or any other layers you need.
     Default: ""
   PrincipalIdClaims:
     Type: String
@@ -168,6 +175,7 @@ Conditions:
     - !Condition UseCustomLogGroup
     - !Condition CreateManagedLogGroup
   HasJwksPreCachedFilePath: !Not [!Equals [!Ref JwksPreCachedFilePath, ""]]
+  HasLambdaLayers: !Not [!Equals [!Ref LambdaLayers, ""]]
 
 Resources:
   OidcAuthorizerLogGroup:
@@ -189,6 +197,10 @@ Resources:
       MemorySize: !Ref LambdaMemorySize
       Architectures:
         - arm64
+      Layers: !If
+        - HasLambdaLayers
+        - !Split [",", !Ref LambdaLayers]
+        - !Ref "AWS::NoValue"
       LoggingConfig: !If
         - ConfigureLogging
         - LogGroup: !If


### PR DESCRIPTION
## Related to #20 

## Summary
Adds support for `JWKS_PRE_CACHED_FILE_PATH` to load JWKS keys from a pre-cached file on disk before fetching from the JWKS URI endpoint. This improves cold start performance by avoiding the initial network call.

## Benefits
**Faster cold starts**: avoids initial network call to JWKS endpoint
**Graceful fallback**: if the file is invalid or missing, falls back to fetching from JWKS URI
**Optional**: backward compatible, no breaking changes

## Usage
Set the `JWKS_PRE_CACHED_FILE_PATH` environment variable to a file path accessible from the Lambda execution environment (e.g., `/opt/jwks.json` for Lambda layers, or relative to the Lambda package root). The file should contain a valid JWKS JSON structure matching your OIDC provider's JWKS format.

Additionally, you are responsible for packaging this `jwks.json` as a zip file, creating a lambda layer, updating the deployed auth lambda function to use the lambda layer.

- Closes #20 


